### PR TITLE
dev/warn-on-no-config

### DIFF
--- a/src/uzbl-browser
+++ b/src/uzbl-browser
@@ -40,10 +40,16 @@ done
 # if no config exists yet in the recommended location, put the default (recommended) config there
 if [ ! -f $XDG_CONFIG_HOME/uzbl/config ]
 then
+	if [ ! -r $PREFIX/share/uzbl/examples/config/config ]
+	then
+		echo "Error: Global config not found; please check if your distribution ships them separately"
+		exit 3
+	fi
 	if ! cp $PREFIX/share/uzbl/examples/config/config $XDG_CONFIG_HOME/uzbl/config
 	then
 		echo "Could not copy default config to $XDG_CONFIG_HOME/uzbl/config" >&2
-		exit 3
+		# Run with the global configs as a last resort
+		config="--config $PREFIX/share/uzbl/examples/config/config"
 	fi
 fi
 
@@ -63,4 +69,4 @@ DAEMON_PID=${DAEMON_SOCKET}.pid
 	uzbl-event-manager -va start
 #fi
 
-exec uzbl-core "$@" --connect-socket $DAEMON_SOCKET
+exec uzbl-core "$@" $config --connect-socket $DAEMON_SOCKET


### PR DESCRIPTION
If the copy fails, we can at least run with the configuration under $PREFIX. Related to RHBZ#632800 (https://bugzilla.redhat.com/show_bug.cgi?id=632800).
