### PR TITLE
dev/add-new-keybindings

### DIFF
--- a/examples/config/config
+++ b/examples/config/config
@@ -259,7 +259,9 @@ set ebind     = @mode_bind global,-insert
 
 # Yanking & pasting binds
 @cbind  yu  = sh 'echo -n $6 | xclip'
+@cbind  yU  = sh 'echo -n $8 | xclip' \@SELECTED_URI
 @cbind  yy  = sh 'echo -n $7 | xclip'
+@cbind  yY  = sh 'echo -n $8 | xclip' \@SELECTED_URI
 
 # Clone current window
 @cbind  c   = sh 'uzbl-browser -u $6'


### PR DESCRIPTION
Add some new keybindings.
- <KP_Enter> is now treated like <Enter>
- <Multi_key> is ignored (may really be a GTK issue however. When used in insert mode, <Multi_key> is "pressed" in command mode until focus changes away then back.
- Add navigation keybindings (Ctrl-f and Ctrl-b for full-page, Home/End for top/bottom)
- Add gy binding (replaces existing gY) and make gY do the NEW_TAB_NEXT variant (matches gn/gN and go/gO)
- Add 'clone' binding to open a new window with the current url (c). gC is already taken, so gc/gC isn't possible. Using gd/gD instead (duplicate for a mnemonic).
- Add yU/yY bindings to yank the hovered link's destination into the clipboard.
