### PR TITLE
History script error

### DIFF
--- a/examples/data/scripts/load_url_from_history.sh
+++ b/examples/data/scripts/load_url_from_history.sh
@@ -13,7 +13,7 @@ DMENU_OPTIONS="xmms vertical resize"
 # goto=$(awk '{print $3}' $history_file | sort -u | dmenu -i)
 if [ -z "$DMENU_HAS_VERTICAL" ]; then
     current=$(tail -n 1 "$UZBL_HISTORY_FILE" | awk '{print $3}');
-    goto=$((echo $current; awk '{print $3}' "$UZBL_HISTORY_FILE" | grep -v "^$current\$" | sort -u) | $DMENU)
+    goto=$($(echo $current; awk '{print $3}' "$UZBL_HISTORY_FILE" | grep -v "^$current\$" | sort -u) | $DMENU)
 else
     # choose an item in reverse order, showing also the date and page titles
     # pick the last field from the first 3 fields. this way you can pick a url (prefixed with date & time) or type just a new url.


### PR DESCRIPTION
Hi,

I get this error when loading history with the 2010.11.25 tagged version:

<pre>
`/usr/local/share/uzbl/examples/data/scripts/load_url_from_history.sh: 20: Syntax error: Missing '))'`
</pre>


... which is fixed by this small patch.

HTH. :)
