### PR TITLE
Fix mem leak in parse command parts

### DIFF
--- a/src/uzbl-core.c
+++ b/src/uzbl-core.c
@@ -1161,8 +1161,10 @@ parse_command_parts(const gchar *line, GArray *a) {
     CommandInfo *c = NULL;
 
     gchar *exp_line = expand(line, 0);
-    if(exp_line[0] == '\0')
+    if(exp_line[0] == '\0') {
+        g_free(exp_line);
         return NULL;
+    }
 
     /* separate the line into the command and its parameters */
     gchar **tokens = g_strsplit(exp_line, " ", 2);


### PR DESCRIPTION
This patch fixes a little memory leak in the parse_command_parts-function. Expand may return "" on something like "@@@@" and parse_command_parts didn't free the empty string but returned NULL immediately.
