### PR TITLE
Fix vim syntax

### DIFF
--- a/extras/vim/syntax/uzbl.vim
+++ b/extras/vim/syntax/uzbl.vim
@@ -37,8 +37,8 @@ syn keyword uzblKeyword menu_remove menu_link_remove menu_image_remove
 syn keyword uzblKeyword menu_editable_remove hardcopy include
 
 " Match 'js' and 'sh' only without a dot in front
-syn match uzblKeyword /\.\@<!sh/
-syn match uzblKeyword /\.\@<!js/
+syn match uzblKeyword /\.\@<!sh\s\+/
+syn match uzblKeyword /\.\@<!js\s\+/
 
 " Comments
 syn match uzblTodo /TODO:/ contained


### PR DESCRIPTION
Hi there,
I just did some small changes to the uzbl vim syntax file. We were modifying the 'iskeyword' setting in a manner that broke the expected behavior of movement keys and insert-completion.

Cheers,
Gregor
