### PR TITLE
dev/add-reload-plugin

### DIFF
--- a/examples/config/config
+++ b/examples/config/config
@@ -112,10 +112,11 @@ set uri_section       = <span foreground="#99FF66">\@[\@uri]\@</span>
 set name_section      = <span foreground="khaki">\@[\@NAME]\@</span>
 set status_section    = <span foreground="orange">\@status_message</span>
 set selected_section  = <span foreground="#606060">\@[\@SELECTED_URI]\@</span>
+set reload_section    = <span foreground="#909090">\@[\@reload.interval]\@</span>
 
 set download_section  = <span foreground="white">\@downloads</span>
 
-set status_format       = <span font_family="monospace">@mode_section @keycmd_section @progress_section @name_section @status_section @scroll_section @selected_section @download_section</span>
+set status_format       = <span font_family="monospace">@mode_section @keycmd_section @progress_section @reload_section @name_section @status_section @scroll_section @selected_section @download_section</span>
 set status_format_right = <span font_family="monospace"><span foreground="#666">uri:</span> @uri_section</span>
 
 set title_format_long = \@keycmd_prompt \@raw_modcmd \@raw_keycmd \@TITLE - Uzbl browser <\@NAME> \@SELECTED_URI
@@ -245,6 +246,8 @@ set ebind     = @mode_bind global,-insert
 @cbind  S   = stop
 @cbind  r   = reload
 @cbind  R   = reload_ign_cache
+@cbind  <Ctrl>R<Interval:>_ = event RELOAD_WATCH %s
+@cbind  <Ctrl>r             = event RELOAD_UNWATCH
 
 # Zoom binds
 @cbind  +   = zoom_in

--- a/examples/data/plugins/reload.py
+++ b/examples/data/plugins/reload.py
@@ -1,0 +1,41 @@
+from threading import Timer
+
+
+UZBL_PIDS = {}
+
+
+def reload_unwatch(uzbl, _=''):
+    if uzbl.pid in UZBL_PIDS:
+        del UZBL_PIDS[uzbl.pid]
+        uzbl.config['reload.interval'] = ''
+
+
+def reload_thread(uzbl, interval):
+    uzbl.send('reload')
+    if uzbl.pid in UZBL_PIDS:
+        reload_unwatch(uzbl)
+        uzbl.send('event RELOAD_WATCH %s' % interval)
+
+
+def reload_watch(uzbl, interval):
+    try:
+        t = float(interval)
+        UZBL_PIDS[uzbl.pid] = uzbl
+        Timer(t, reload_thread, [uzbl, interval]).start()
+        uzbl.config['reload.interval'] = interval
+    except:
+        pass
+
+
+def init(uzbl):
+    '''Export functions and connect handlers to events.'''
+
+    connect_dict(uzbl, {
+        'RELOAD_WATCH':   reload_watch,
+        'RELOAD_UNWATCH': reload_unwatch,
+    })
+
+    export_dict(uzbl, {
+        'reload_watch':   reload_watch,
+        'reload_unwatch': reload_unwatch,
+    })


### PR DESCRIPTION
Add a plugin that allows the user to continuously reload a URI. Also has a binding to stop reloading. Also added a statusbar section to show the reload interval (seconds, floats allowed).
