### PR TITLE
Check if file exist before trying to run it

### DIFF
--- a/src/util.c
+++ b/src/util.c
@@ -134,7 +134,7 @@ find_existing_file(const gchar* path_list) {
 
     char *basename = strrchr(path_list_dup, ':');
     if(!basename)
-      return path_list_dup;
+      return file_exists(path_list_dup) ? path_list_dup : NULL;
 
     basename[0] = '\0';
     basename++;


### PR DESCRIPTION
find_existing_file modified to return NULL when file does not exist
even for simple paths.

run_external_js and spawn prints error messages when a file could not be
loaded.
