### PR TITLE
Separate commands with a newline

### DIFF
--- a/examples/data/scripts/per-site-settings.py
+++ b/examples/data/scripts/per-site-settings.py
@@ -93,7 +93,7 @@ def write_to_socket(commands, sockpath):
     sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
     sock.connect(sockpath)
     for command in commands:
-        sock.send(command)
+        sock.send('%s\n' % command)
     sock.close()
 
 


### PR DESCRIPTION
Makes pss work when there's more than one command to run. Oops.
