### PR TITLE
dev/support-pss-directories

### DIFF
--- a/examples/data/scripts/per-site-settings.py
+++ b/examples/data/scripts/per-site-settings.py
@@ -116,7 +116,7 @@ if __name__ == '__main__':
         except IndexError:
             fileglob = '*.pss'
 
-        for sett in glob.glob(os.path.join(filepath, fileglob)):
+        for sett in sorted(glob.glob(os.path.join(filepath, fileglob))):
             with open(sett, 'r') as sfin:
                 fin.write(sfin.read())
 


### PR DESCRIPTION
Support a directory of pss commands. The (optional) second argument is a glob to use (defaults to '*.pss')
