### PR TITLE
Exit lag workaround

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -401,6 +401,10 @@ chain(WebKitWebView *page, GArray *argv, GString *result) {
 void
 close_uzbl (WebKitWebView *page, GArray *argv, GString *result) {
     (void)page; (void)argv; (void)result;
+	// hide window a soon as possible to avoid getting stuck with a
+	// non-response window in the cleanup steps
+	if (uzbl.gui.main_window)
+		gtk_widget_destroy(uzbl.gui.main_window);
     gtk_main_quit ();
 }
 


### PR DESCRIPTION
avoid lag when closing uzbl by destroying the window before doing cleanup
