### PR TITLE
Changed python scripts headers

### DIFF
--- a/examples/data/scripts/auth.py
+++ b/examples/data/scripts/auth.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import gtk
 import sys

--- a/examples/data/scripts/per-site-settings.py
+++ b/examples/data/scripts/per-site-settings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Per-site settings plugin
 
 # Example configuration usage:

--- a/examples/data/scripts/scheme.py
+++ b/examples/data/scripts/scheme.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os, subprocess, sys, urlparse
 


### PR DESCRIPTION
Hi,
I installed uzbl in my system Arch linux, which have installed both python2 and python3 packages. python is a alias for python3 bin, and uzbl doesn't like that. I've changed the header of the python executables to make it work on my system. I think most of the current distributions follows the arch approach.

Thanks!
