### PR TITLE
Ignore consumed keyboard modifiers

### DIFF
--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -143,7 +143,7 @@ key_press_cb (GtkWidget* window, GdkEventKey* event) {
     (void) window;
 
     if(event->type == GDK_KEY_PRESS)
-        key_to_event(event->keyval, event->state, event->is_modifier, GDK_KEY_PRESS);
+        key_to_event(event);
 
     return uzbl.behave.forward_keys ? FALSE : TRUE;
 }
@@ -153,7 +153,7 @@ key_release_cb (GtkWidget* window, GdkEventKey* event) {
     (void) window;
 
     if(event->type == GDK_KEY_RELEASE)
-        key_to_event(event->keyval, event->state, event->is_modifier, GDK_KEY_RELEASE);
+        key_to_event(event);
 
     return uzbl.behave.forward_keys ? FALSE : TRUE;
 }

--- a/src/events.c
+++ b/src/events.c
@@ -357,19 +357,27 @@ guint button_to_modifier(guint buttonval) {
 
 /* Transform gdk key events to our own events */
 void
-key_to_event(guint keyval, guint state, guint is_modifier, gint mode) {
+key_to_event(GdkEventKey *event) {
     gchar ucs[7];
     gint ulen;
     gchar *keyname;
-    guint32 ukval = gdk_keyval_to_unicode(keyval);
+    guint32 ukval = gdk_keyval_to_unicode(event->keyval);
     gchar *modifiers = NULL;
-    guint mod = key_to_modifier (keyval);
+    guint mod = key_to_modifier (event->keyval);
+	guint state;
+	GdkModifierType consumed;
+	GdkKeymap *keymap = gdk_keymap_get_default ();
+
+	gdk_keymap_translate_keyboard_state (keymap, event->hardware_keycode,
+                                     event->state, event->group,
+                                     NULL, NULL, NULL, &consumed);
+	state = event->state & ~consumed;
 
     /* Get modifier state including this key press/release */
-    modifiers = get_modifier_mask(mode == GDK_KEY_PRESS ? state | mod : state & ~mod);
+    modifiers = get_modifier_mask(event->type == GDK_KEY_PRESS ? state | mod : state & ~mod);
 
-    if(is_modifier && mod) {
-        send_event(mode == GDK_KEY_PRESS ? MOD_PRESS : MOD_RELEASE, NULL,
+    if(event->is_modifier && mod) {
+        send_event(event->type == GDK_KEY_PRESS ? MOD_PRESS : MOD_RELEASE, NULL,
             TYPE_STR, modifiers,
             TYPE_NAME, get_modifier_mask (mod),
             NULL);
@@ -382,12 +390,12 @@ key_to_event(guint keyval, guint state, guint is_modifier, gint mode) {
         ulen = g_unichar_to_utf8(ukval, ucs);
         ucs[ulen] = 0;
 
-        send_event(mode == GDK_KEY_PRESS ? KEY_PRESS : KEY_RELEASE, NULL,
+        send_event(event->type == GDK_KEY_PRESS ? KEY_PRESS : KEY_RELEASE, NULL,
             TYPE_STR, modifiers, TYPE_STR, ucs, NULL);
     }
     /* send keysym for non-printable chars */
-    else if((keyname = gdk_keyval_name(keyval))){
-        send_event(mode == GDK_KEY_PRESS ? KEY_PRESS : KEY_RELEASE, NULL,
+    else if((keyname = gdk_keyval_name(event->keyval))){
+        send_event(event->type == GDK_KEY_PRESS ? KEY_PRESS : KEY_RELEASE, NULL,
             TYPE_STR, modifiers, TYPE_NAME, keyname, NULL);
     }
 

--- a/src/events.h
+++ b/src/events.h
@@ -7,6 +7,7 @@
 #define __EVENTS__
 
 #include <glib.h>
+#include <gdk/gdk.h>
 #include <stdarg.h>
 
 /* Event system */
@@ -76,7 +77,7 @@ gchar *
 get_modifier_mask(guint state);
 
 void
-key_to_event(guint keyval, guint state, guint is_modifier, gint mode);
+key_to_event(GdkEventKey *event);
 
 void
 button_to_event(guint buttonval, guint state, gint mode);


### PR DESCRIPTION
See commit. Not sure if keymap should be free’d.
