### PR TITLE
Fix minor issues with formfiller and textareas

### DIFF
--- a/examples/data/scripts/formfiller.js
+++ b/examples/data/scripts/formfiller.js
@@ -39,7 +39,7 @@ uzbl.formfiller = {
                 );
                 var input;
                 while ( input = xp_res.iterateNext() ) {
-                    rv += '%' + escape(input.name) + '(textarea):\n' + input.value.replace(/\n%/g,"\n\\%") + '\n%\n';
+                    rv += '%' + escape(input.name) + '(textarea):\n' + input.value.replace(/\n\\/g,"\n\\\\").replace(/\n%/g,"\n\\%") + '%\n';
                 }
             }
             catch (err) { }


### PR DESCRIPTION
The transportation of existing textarea contents to the formfiller file was flawed; special characters weren't escaped properly and it would add an extra newline.
