### PR TITLE
More formfiller fixes

### DIFF
--- a/examples/data/scripts/formfiller.js
+++ b/examples/data/scripts/formfiller.js
@@ -27,6 +27,9 @@ uzbl.formfiller = {
 
                 for( var k = 0; k < inputs.length; ++k ) {
                     var input = inputs[k];
+                    if ( ! input.name ) {
+                        continue
+                    }
                     if ( uzbl.formfiller.inputTypeIsText(input.type) ) {
                         rv += '%' + escape(input.name) + '(' + input.type + '):' + input.value + '\n';
                     } else if ( input.type == 'checkbox' || input.type == 'radio' ) {
@@ -37,8 +40,10 @@ uzbl.formfiller = {
                 var textareas = allFrames[j].document.getElementsByTagName("textarea");
                 for( var k = 0; k < textareas.length; ++k ) {
                     var textarea = textareas[k];
-                    rv += '%' + escape(textarea.name) + '(textarea):\n' + textarea.value.replace(/\n%/g,"\n\\%") + '\n%\n';
-                    rv += '%' + escape(textarea.name) + '(textarea):\n' + textarea.value.replace(/\n\\/g,"\n\\\\").replace(/\n%/g,"\n\\%") + '%\n';
+                    if ( ! textarea.name ) {
+                        continue
+                    }
+                    rv += '%' + escape(textarea.name) + '(textarea):\n' + textarea.value.replace(/(^|\n)\\/g,"$1\\\\").replace(/(^|\n)%/g,"$1\\%") + '\n%\n';
                 }
             }
             catch (err) { }


### PR DESCRIPTION
1) To support the possibility of a textarea not being newline-terminated, do add an additional newline at the end (otherwise the line based formfiller file format gets screwed) and take it out again while applying the formfiller file (you can think of it as being part of the file format).

2) .replace(/\n\/,... and .replace(/\n%/,... wouldn't catch the \ or % at the beginning of the very first line (since that one has no preceding newline). Use (^|\n) in the regex and $1 in the replacement string.

3) Skip elements that don't have a 'name' attribute. We rely on it while applying the form back to the page, so nameless elements in the formfiller file are useless; we should investigate how to fix this issue.

4) Do better escaping against all the layers of interpretation. (Don't know if it was buggy or not, but in any case the new code is cleaner and works.)

5) Fix the recently introduced bug where a line of code seems to have been duplicated with an old version.
