### PR TITLE
javascriptcoregtk-3.0 is required for webkitgtk3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,6 +21,11 @@ endif
 
 REQ_PKGS += libsoup-2.4 gthread-2.0 glib-2.0
 
+# Check for a new glib version
+ifeq ($(shell pkg-config --exists "glib-2.0 >= 2.31.0" && echo 1),1)
+	CPPFLAGS += -DUZBL_GTHREAD_NO_INIT
+endif
+
 ARCH:=$(shell uname -m)
 
 COMMIT_HASH:=$(shell ./misc/hash.sh)

--- a/src/uzbl-core.c
+++ b/src/uzbl-core.c
@@ -962,9 +962,10 @@ initialize(int argc, char** argv) {
     if (uzbl.state.socket_id || uzbl.state.embed)
         uzbl.state.plug_mode = TRUE;
 
+#ifndef UZBL_GTHREAD_NO_INIT
     if (!g_thread_supported())
         g_thread_init(NULL);
-
+#endif
 
     /* TODO: move the handler setup to event_buffer_timeout and disarm the
      * handler in empty_event_buffer? */


### PR DESCRIPTION
Add another pkgconfig check when building with webkitgtk3.

http://koji.fedoraproject.org/koji/getfile?taskID=3459666&name=build.log
