### PR TITLE
Fix missing javascriptcoregtk dependency in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ ifeq ($(USE_GTK3),1)
 	REQ_PKGS += gtk+-3.0 webkitgtk-3.0 javascriptcoregtk-3.0
 	CPPFLAGS = -DG_DISABLE_DEPRECATED -DGTK_DISABLE_DEPRECATED
 else
-	REQ_PKGS += gtk+-2.0 webkit-1.0
+	REQ_PKGS += gtk+-2.0 webkit-1.0 javascriptcoregtk-1.0
 	CPPFLAGS =
 endif
 


### PR DESCRIPTION
The -ljavascriptcoregtk-1.0 flag is required in order to build the application
against GTK2.

At least for me, on Arch Linux, building resulted in:

```
± make
cc   uzbl-core.o callbacks.o io.o events.o cookie-jar.o inspector.o variables.o menu.o commands.o util.o status-bar.o  -pthread -lwebkitgtk-1.0 -lgtk-x11-2.0 -lgdk-x11-2.0 -latk-1.0 -lpangoft2-1.0 -lpangocairo-1.0 -lgdk_pixbuf-2.0 -lcairo -lpango-1.0 -lfreetype -lfontconfig -lsoup-2.4 -lgio-2.0 -lgobject-2.0 -lgmodule-2.0 -lgthread-2.0 -lrt -lglib-2.0 -lX11   -o uzbl-core
/usr/bin/ld: uzbl-core.o: undefined reference to symbol 'JSStringRelease'
/usr/bin/ld: note: 'JSStringRelease' is defined in DSO /usr/lib/libjavascriptcoregtk-1.0.so.0 so try adding it to the linker command line
/usr/lib/libjavascriptcoregtk-1.0.so.0: could not read symbols: Invalid operation
collect2: ld returned 1 exit status
make: *** [uzbl-core] Error 1
```

With this fix, it doesn't.
