### PR TITLE
dev/fix-double-clicking

### DIFF
--- a/README
+++ b/README
@@ -373,6 +373,9 @@ file).
   access the contents of other `file://` URIs. (default 0).
 * `follow_hint_keys`: keys for keyboard-based navigation and link
    highlighting
+* `handle_multi_click`: If set to 1, event handlers attached to `2Button*`
+   and `3Button*` bindings will only be used instead of the default actions in
+   WebKit (default 0).
 * `ssl_ca_file`: File that contains CA certificates.
 * `ssl_verify`: If set to 1, uzbl won't connect to "https" url unless it can
    validate certificate presented by remote server against `ssl_ca_file`.

--- a/src/callbacks.c
+++ b/src/callbacks.c
@@ -196,15 +196,15 @@ button_press_cb (GtkWidget* window, GdkEventButton* event) {
     if(event->type == GDK_2BUTTON_PRESS || event->type == GDK_3BUTTON_PRESS) {
         if(event->button == 1 && !(context & WEBKIT_HIT_TEST_RESULT_CONTEXT_EDITABLE) && (context & WEBKIT_HIT_TEST_RESULT_CONTEXT_DOCUMENT)) {
             sendev    = TRUE;
-            propagate = TRUE;
+            propagate = uzbl.state.handle_multi_button;
         }
         else if(event->button == 2 && !(context & WEBKIT_HIT_TEST_RESULT_CONTEXT_EDITABLE)) {
             sendev    = TRUE;
-            propagate = TRUE;
+            propagate = uzbl.state.handle_multi_button;
         }
-        else if(event->button > 3) {
+        else if(event->button >= 3) {
             sendev    = TRUE;
-            propagate = TRUE;
+            propagate = uzbl.state.handle_multi_button;
         }
     }
 

--- a/src/uzbl-core.h
+++ b/src/uzbl-core.h
@@ -113,6 +113,7 @@ typedef struct {
     /* Events */
     int             socket_id;
     gboolean        events_stdout;
+    gboolean        handle_multi_button;
     GPtrArray*      event_buffer;
     gchar**         connect_socket_names;
 } State;

--- a/src/variables.c
+++ b/src/variables.c
@@ -735,6 +735,8 @@ const struct var_name_to_ptr_t {
     { "verbose",                PTR_V_INT(uzbl.state.verbose,                   1,   NULL)},
     { "print_events",           PTR_V_INT(uzbl.state.events_stdout,             1,   NULL)},
 
+    { "handle_multi_button",    PTR_V_INT(uzbl.state.handle_multi_button,        1,   NULL)},
+
     { "show_status",            PTR_V_INT_GETSET(show_status)},
     { "status_top",             PTR_V_INT(uzbl.behave.status_top,               1,   set_status_top)},
     { "status_format",          PTR_V_STR(uzbl.behave.status_format,            1,   NULL)},


### PR DESCRIPTION
The keyevent is always sent for multiple clicks (that aren't in an edit field for left and middle clicks), but the propogation of the event through to webkit can be suppressed if the user wants something else to happen.

This allows double and triple click selections (by word and paragraph, respectively) work again.
