### PR TITLE
Fix an off-by-one error

### DIFF
--- a/examples/data/scripts/load_cookies.sh
+++ b/examples/data/scripts/load_cookies.sh
@@ -14,7 +14,7 @@ BEGIN {
 }
 $0 ~ /^#HttpOnly_/ {
     gsub(/@/, "\\@")
-    printf("add_cookie \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\"\n", substr($1,length("#HttpOnly_"),length($1)), $3, $6, $7, scheme[$4], $5)
+    printf("add_cookie \"%s\" \"%s\" \"%s\" \"%s\" \"%s\" \"%s\"\n", substr($1,length("#HttpOnly_")+1,length($1)), $3, $6, $7, scheme[$4], $5)
 }
 $0 !~ /^#/ {
     gsub(/@/, "\\@")


### PR DESCRIPTION
Awk strings are 1-indexed, so 1 needs to be added to the starting index.
