### PR TITLE
makefile fixes for uzbl-core on gtk2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -172,7 +172,7 @@ install: install-uzbl-core install-uzbl-browser install-uzbl-tabbed
 install-dirs:
 	[ -d "$(INSTALLDIR)/bin" ] || install -d -m755 $(INSTALLDIR)/bin
 
-install-uzbl-core: all install-dirs
+install-uzbl-core: uzbl-core install-dirs
 	install -d $(INSTALLDIR)/share/uzbl/
 	install -d $(DOCDIR)
 	install -m644 docs/* $(DOCDIR)/


### PR DESCRIPTION
Running make install-uzbl-core with webkit1 and gtk2 failed, because it tried to link with gtk3 and also build the browser.  These two commits fix those two problems.
