### PR TITLE
detect stale sockets on init

### DIFF
--- a/uzbl/event_manager.py
+++ b/uzbl/event_manager.py
@@ -390,6 +390,7 @@ def start_action():
         del_pid_file(pid_file)
 
     listener = Listener(opts.server_socket)
+    listener.start()
     plugind = PluginDirectory()
     daemon = UzblEventDaemon(listener, plugind)
     daemon.run()


### PR DESCRIPTION
detects and unlinks stale event manager sockets before trying to bind 
