### PR TITLE
Fix/bad quoting of mode vars

### DIFF
--- a/tests/event-manager/testmode.py
+++ b/tests/event-manager/testmode.py
@@ -42,8 +42,8 @@ class ModeTest(unittest.TestCase):
         mode.parse_mode_config(('mode0', 'foo', '=', 'default'))
 
         mode.parse_mode_config(('mode1', 'foo', '=', 'xxx'))
-        mode.parse_mode_config(('mode1', 'bar', '=', 'yyy'))
-        mode.parse_mode_config(('mode1', 'baz', '=', 'zzz'))
+        mode.parse_mode_config('mode1 bar = "spam spam"')
+        mode.parse_mode_config('mode1 baz = foo="baz"')
 
         mode.parse_mode_config(('mode2', 'foo', '=', 'XXX'))
         mode.parse_mode_config(('mode2', 'spam', '=', 'spam'))
@@ -59,8 +59,8 @@ class ModeTest(unittest.TestCase):
         self.assertIn('bar', config)
         self.assertIn('baz', config)
         self.assertEqual(config['foo'], 'xxx')
-        self.assertEqual(config['bar'], 'yyy')
-        self.assertEqual(config['baz'], 'zzz')
+        self.assertEqual(config['bar'], 'spam spam')
+        self.assertEqual(config['baz'], 'foo="baz"')
 
     def test_mode_overwrite_vars(self):
         mode, config = ModePlugin[self.uzbl], Config[self.uzbl]
@@ -74,8 +74,8 @@ class ModeTest(unittest.TestCase):
         self.assertIn('baz', config)
         self.assertIn('spam', config)
         self.assertEqual(config['foo'], 'XXX')
-        self.assertEqual(config['bar'], 'yyy')
-        self.assertEqual(config['baz'], 'zzz')
+        self.assertEqual(config['bar'], 'spam spam')
+        self.assertEqual(config['baz'], 'foo="baz"')
         self.assertEqual(config['spam'], 'spam')
 
     def test_default_mode(self):

--- a/uzbl/arguments.py
+++ b/uzbl/arguments.py
@@ -79,13 +79,18 @@ class Arguments(tuple):
         if len(self._ref) < 1:
             return ''
         rfrm = self._ref[frm]
-        if to is None or len(self._ref) <= to+1:
+        if to is None or len(self._ref) <= to + 1:
             rto = len(self._raw)
         else:
-            rto = self._ref[to+1]-1
+            rto = self._ref[to + 1] - 1
         return ''.join(self._raw[rfrm:rto])
 
 splitquoted = Arguments  # or define a function?
+
+
+def is_quoted(s):
+    return s and s[0] == s[-1] and s[0] in "'\""
+
 
 def unquote(s):
     '''
@@ -93,7 +98,6 @@ def unquote(s):
         escape sequences interpreted
     '''
 
-    if s and s[0] == s[-1] and s[0] in ['"', "'"]:
+    if is_quoted(s):
         return ast.literal_eval(s)
     return ast.literal_eval('"' + s + '"')
-

--- a/uzbl/plugins/mode.py
+++ b/uzbl/plugins/mode.py
@@ -1,9 +1,8 @@
 from collections import defaultdict
 
-import uzbl.plugins.config
 from .on_set import OnSetPlugin
 from .config import Config
-from uzbl.arguments import splitquoted
+from uzbl.arguments import splitquoted, is_quoted
 from uzbl.ext import PerInstancePlugin
 
 
@@ -28,7 +27,15 @@ class ModePlugin(PerInstancePlugin):
         mode = args[0]
         key = args[1]
         assert args[2] == '=', 'invalid mode config set syntax'
-        value = args.raw(3).strip()
+
+        # Use the rest of the line verbatim as the value unless it's a
+        # single properly quoted string
+        if len(args) == 4 and is_quoted(args.raw(3)):
+            value = args[3]
+        else:
+            value = args.raw(3).strip()
+
+        self.logger.debug('value %r', value)
 
         self.mode_config[mode][key] = value
         config = Config[self.uzbl]
@@ -60,4 +67,3 @@ class ModePlugin(PerInstancePlugin):
         config = Config[self.uzbl]
         if mode and config.get('mode', None) == mode:
             self.uzbl.event('MODE_CHANGED', mode)
-


### PR DESCRIPTION
if the value to a mode config is a properly quoted string use the
interpreted value. This allows you to use the more strict looking style
of quoting your arguments in the config.
- @command  status_background   = #202020
- @command  status_background   = "#202020"
