### PR TITLE
Make scheme.py python3 compatible.

### DIFF
--- a/examples/data/scripts/scheme.py
+++ b/examples/data/scripts/scheme.py
@@ -1,6 +1,11 @@
 #!/usr/bin/env python
 
-import os, subprocess, sys, urlparse
+import os, subprocess, sys
+
+try:
+  import urllib.parse as urlparse
+except ImportError:
+  import urlparse
 
 def detach_open(cmd):
     # Thanks to the vast knowledge of Laurence Withers (lwithers) and this message:
@@ -10,7 +15,7 @@ def detach_open(cmd):
         for i in range(3): os.dup2(null,i)
         os.close(null)
         subprocess.Popen(cmd)
-    print 'USED'
+    print('USED')
 
 if __name__ == '__main__':
     uri = sys.argv[1]


### PR DESCRIPTION
This script was throwing a bunch of errors a few days ago when I was running uzbl-tabbed with Python 3. This patch makes the script Python 3 compatible while maintaining backwards compatibility with Python 2.
