### PR TITLE
Experimental feature: named sessions in uzbl-tabbed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ test-uzbl-browser-sandbox: sandbox uzbl-browser sandbox-install-uzbl-browser san
 
 test-uzbl-tabbed-sandbox: sandbox uzbl-browser sandbox-install-uzbl-browser sandbox-install-uzbl-tabbed sandbox-install-example-data
 	. ./sandbox/env.sh && ${PYTHON} -S `which uzbl-event-manager` restart -avv
-	. ./sandbox/env.sh && uzbl-tabbed
+	. ./sandbox/env.sh && uzbl-tabbed $(TABBED_EXTRA_ARGS)
 	. ./sandbox/env.sh && ${PYTHON} -S `which uzbl-event-manager` stop -avv
 	make DESTDIR=./sandbox uninstall
 	rm -rf ./sandbox/usr

--- a/bin/uzbl-tabbed
+++ b/bin/uzbl-tabbed
@@ -1317,6 +1317,20 @@ if __name__ == "__main__":
     # Parse command line options
     (options, uris) = parser.parse_args()
 
+    #Fail if user wants session support and has an old session file
+    #(used to be DATA_DIR/session)
+    if not options.nosession:
+        old_session_file = os.path.join(DATA_DIR, 'session')
+        if os.path.exists(old_session_file):
+            s = ('*** Error: Found old session file in\n\t{}\n'
+                'I will not run until you have either deleted it or moved it '
+                'to\n\t{}\n'
+                'Watch out for the existing files there!\n').format(
+                    old_session_file, config['saved_sessions_dir']
+                )
+            sys.stderr.write(s)
+            sys.exit(-1)
+
     if options.sessionname is not None:
         session_basename = options.sessionname
         config['session_file'] = os.path.join(

--- a/bin/uzbl-tabbed
+++ b/bin/uzbl-tabbed
@@ -1303,6 +1303,8 @@ if __name__ == "__main__":
     parser = OptionParser(usage=usage)
     parser.add_option('-l', '--load-session', dest='sessionname',
       type='string', help="load a named session")
+    parser.add_option('-L', '--list-sessions', dest='listsessions',
+      action='store_true', help="list the named sessions")
     parser.add_option('-n', '--no-session', dest='nosession',
       action='store_true', help="ignore session saving a loading.")
     parser.add_option('-v', '--verbose', dest='verbose',
@@ -1335,6 +1337,12 @@ if __name__ == "__main__":
         session_basename = options.sessionname
         config['session_file'] = os.path.join(
             config['saved_sessions_dir'], session_basename)
+
+    if options.listsessions:
+        children = os.listdir(config['saved_sessions_dir'])
+        for i in children:
+            print i
+        sys.exit(0)
 
     if options.nosession:
         config['save_session'] = False

--- a/bin/uzbl-tabbed
+++ b/bin/uzbl-tabbed
@@ -130,8 +130,7 @@
 
 
 # Todo:
-#   - add command line options to use a different session file, not use a
-#     session file and or open a uri on starup.
+#   - add command line options to open a uri on startup.
 #   - ellipsize individual tab titles when the tab-list becomes over-crowded
 #   - add "<" & ">" arrows to tablist to indicate that only a subset of the
 #     currently open tabs are being displayed on the tablist.
@@ -213,7 +212,7 @@ config = {
   # Session options
   'save_session':           True,   # Save session in file when quit
   'saved_sessions_dir':     os.path.join(DATA_DIR, 'sessions/'),
-  'session_file':           os.path.join(DATA_DIR, 'session'),
+  'session_file':           os.path.join(DATA_DIR, 'sessions/session'),
   'autosave_session':       False,  # Save session for every tab change
 
   # Inherited uzbl options
@@ -824,16 +823,22 @@ class UzblTabbed:
 
 
     def run_preset_command(self, cmd, *args):
-        if len(args) < 1:
+        if len(args) < 1 and cmd != "list":
             error("parse_command: invalid preset command")
 
         elif cmd == "save":
+            #TODO this should probably change config['session_file'] as well,
+            #otherwise both files will have the same content at this point
             path = os.path.join(config['saved_sessions_dir'], args[0])
             self.save_session(path)
 
         elif cmd == "load":
             path = os.path.join(config['saved_sessions_dir'], args[0])
             self.load_session(path)
+
+        elif cmd == "open":
+            cmd = ['uzbl-tabbed', '-l', str(args[0])]
+            gobject.spawn_async(cmd, flags=gobject.SPAWN_SEARCH_PATH)
 
         elif cmd == "del":
             path = os.path.join(config['saved_sessions_dir'], args[0])
@@ -845,7 +850,9 @@ class UzblTabbed:
         elif cmd == "list":
             # FIXME: what argument is this supposed to be passed,
             # and why?
-            uzbl = self.get_tab_by_name(int(args[0]))
+            uzbl = self.tabs[self.notebook.get_nth_page(
+                self.notebook.get_current_page()
+            )]
             if uzbl:
                 if not os.path.isdir(config['saved_sessions_dir']):
                     js = "js alert('No saved presets.');"
@@ -853,8 +860,8 @@ class UzblTabbed:
 
                 else:
                     listdir = os.listdir(config['saved_sessions_dir'])
-                    listdir = "\\n".join(listdir)
-                    js = "js alert('Session presets:\\n\\n%s');" % listdir
+                    listdir = r"\\n".join(listdir)
+                    js = r"js alert('Session presets:\\n\\n%s');" % listdir
                     uzbl._client.send(js)
 
             else:
@@ -1294,6 +1301,8 @@ if __name__ == "__main__":
     # Build command line parser
     usage = "usage: %prog [OPTIONS] {URIS}..."
     parser = OptionParser(usage=usage)
+    parser.add_option('-l', '--load-session', dest='sessionname',
+      type='string', help="load a named session")
     parser.add_option('-n', '--no-session', dest='nosession',
       action='store_true', help="ignore session saving a loading.")
     parser.add_option('-v', '--verbose', dest='verbose',
@@ -1307,6 +1316,11 @@ if __name__ == "__main__":
 
     # Parse command line options
     (options, uris) = parser.parse_args()
+
+    if options.sessionname is not None:
+        session_basename = options.sessionname
+        config['session_file'] = os.path.join(
+            config['saved_sessions_dir'], session_basename)
 
     if options.nosession:
         config['save_session'] = False

--- a/bin/uzbl-tabbed
+++ b/bin/uzbl-tabbed
@@ -853,8 +853,6 @@ class UzblTabbed:
                 error("parse_command: preset %r does not exist." % path)
 
         elif cmd == "list":
-            # FIXME: what argument is this supposed to be passed,
-            # and why?
             uzbl = self.tabs[self.notebook.get_nth_page(
                 self.notebook.get_current_page()
             )]

--- a/bin/uzbl-tabbed
+++ b/bin/uzbl-tabbed
@@ -824,7 +824,8 @@ class UzblTabbed:
 
 
     def run_preset_command(self, cmd, *args):
-        if len(args) < 1 and cmd != "list":
+        commands_without_args = ['list', 'backup']
+        if len(args) < 1 and cmd not in commands_without_args:
             error("parse_command: invalid preset command")
 
         elif cmd == "save":
@@ -832,6 +833,9 @@ class UzblTabbed:
             #otherwise both files will have the same content at this point
             path = os.path.join(config['saved_sessions_dir'], args[0])
             self.save_session(path)
+
+        elif cmd == "backup":
+            self.backup_session()
 
         elif cmd == "load":
             path = os.path.join(config['saved_sessions_dir'], args[0])

--- a/bin/uzbl-tabbed
+++ b/bin/uzbl-tabbed
@@ -837,11 +837,12 @@ class UzblTabbed:
         elif cmd == "backup":
             self.backup_session()
 
-        elif cmd == "load":
+        elif cmd == "merge":
             path = os.path.join(config['saved_sessions_dir'], args[0])
             self.load_session(path)
 
         elif cmd == "open":
+            #for interactive use (completion, etc), session_open.sh is better
             cmd = ['uzbl-tabbed', '-l', str(args[0])]
             gobject.spawn_async(cmd, flags=gobject.SPAWN_SEARCH_PATH)
 
@@ -1203,10 +1204,13 @@ class UzblTabbed:
         fh.close()
 
 
-    def session_backup_filename(self, session_file):
+    @staticmethod
+    def session_backup_filename(session_file):
         '''Get the backup naming scheme for session files'''
 
-        return session_file + '.bkp.' + str(time.time())
+        dirname = os.path.dirname(session_file)
+        basename = os.path.basename(session_file)
+        return dirname + os.sep + '.' + basename + '.bkp.' + str(time.time())
 
     def backup_session(self, session_file=None):
         '''Make a backup of the session file'''
@@ -1363,7 +1367,10 @@ if __name__ == "__main__":
     if options.listsessions:
         children = os.listdir(config['saved_sessions_dir'])
         for i in children:
-            print i
+            #NOTE: this is coupled to a specific implementation of
+            #UzblTabbed.session_backup_filename, i.e. using dotfiles to hide the
+            #backups
+            if not i.startswith('.'): print i
         sys.exit(0)
 
     if options.nosession:

--- a/bin/uzbl-tabbed
+++ b/bin/uzbl-tabbed
@@ -88,7 +88,7 @@
 # Session options:
 #   save_session            = 1
 #   json_session            = 0
-#   session_file            = $HOME/.local/share/uzbl/session
+#   session_file            = $HOME/.local/share/uzbl/sessions/session
 #   autosave_session        = 0
 #
 # Inherited uzbl options:
@@ -214,6 +214,7 @@ config = {
   'saved_sessions_dir':     os.path.join(DATA_DIR, 'sessions/'),
   'session_file':           os.path.join(DATA_DIR, 'sessions/session'),
   'autosave_session':       False,  # Save session for every tab change
+  'backup_session':         True,   # Keep a backup of session file when loading
 
   # Inherited uzbl options
   'icon_path':              os.path.join(DATA_DIR, 'uzbl.png'),
@@ -1200,6 +1201,20 @@ class UzblTabbed:
         fh.close()
 
 
+    def session_backup_filename(self, session_file):
+        '''Get the backup naming scheme for session files'''
+
+        return session_file + '.bkp.' + str(time.time())
+
+    def backup_session(self, session_file=None):
+        '''Make a backup of the session file'''
+
+        if session_file is None:
+            session_file = config['session_file']
+
+        new_name = self.session_backup_filename(session_file)
+        self.save_session(new_name)
+
     def load_session(self, session_file=None):
         '''Load a saved session from file.'''
 
@@ -1247,9 +1262,14 @@ class UzblTabbed:
         for (index, (uri, title)) in enumerate(tabs):
             self.new_tab(uri=uri, title=title, switch=(curtab==index))
 
-        # A saved session has been loaded now delete it.
+        # A saved session has been loaded, now figure out what to do with the
+        # original session file.
         if delete_loaded and os.path.exists(session_file):
-            os.remove(session_file)
+            if config['backup_session']: #No need to call backup_session() here
+                new_name = self.session_backup_filename(session_file)
+                os.rename(session_file, new_name)
+            else:
+                os.remove(session_file)
 
 
     def quitrequest(self, *args):

--- a/examples/config/config
+++ b/examples/config/config
@@ -421,6 +421,7 @@ set preset = event PRESET_TABS
 @cbind  gs<preset save:>_   = @preset save %s
 @cbind  glo<preset load:>_  = @preset load %s
 @cbind  gd<preset del:>_    = @preset del %s
+@cbind  gb                  = @preset backup
 # This doesn't work right now.
 #@cbind  gli                 = @preset list
 

--- a/examples/config/config
+++ b/examples/config/config
@@ -399,7 +399,6 @@ set formfiller = spawn @scripts_dir/formfiller.sh
 # Tab opening
 @cbind  gn              = event NEW_TAB
 @cbind  gN              = event NEW_TAB_NEXT
-@cbind  go<uri:>_       = event NEW_TAB %s
 @cbind  gO<uri:>_       = event NEW_TAB_NEXT %s
 
 # Closing / resting
@@ -414,15 +413,22 @@ set formfiller = spawn @scripts_dir/formfiller.sh
 @cbind  gi<index:>_     = event GOTO_TAB %s
 @cbind  <Ctrl><Left>    = event MOVE_CURRENT_TAB_LEFT
 @cbind  <Ctrl><Right>   = event MOVE_CURRENT_TAB_RIGHT
-@cbind  gm<index:>_     = event MOVE_CURRENT_TAB %s
 
-# Preset loading
+# Named sessions
+# Possible commands:
+#    @preset save %s
+#    @preset merge %s
+#    @preset open %s   [DEPRECATED, for interactive menu use session_open.sh]
+#    @preset del %s
+#    @preset list      [DEPRECATED, for interactive menu use session_list.sh]
+#    @preset backup
 set preset = event PRESET_TABS
-@cbind  gs<preset save:>_   = @preset save %s
-@cbind  glo<preset load:>_  = @preset load %s
-@cbind  gd<preset del:>_    = @preset del %s
+@cbind  gs<save session as:>_   = @preset save %s
+@cbind  gm<merge named session:>_  = @preset merge %s
+@cbind  gd<delete named session:>_    = @preset del %s
 @cbind  gb                  = @preset backup
-@cbind  gli                 = @preset list
+@cbind  go  = spawn @scripts_dir/session_open.sh
+@cbind  gli = spawn @scripts_dir/session_list.sh
 
 # === Context menu items =====================================================
 

--- a/examples/config/config
+++ b/examples/config/config
@@ -422,8 +422,7 @@ set preset = event PRESET_TABS
 @cbind  glo<preset load:>_  = @preset load %s
 @cbind  gd<preset del:>_    = @preset del %s
 @cbind  gb                  = @preset backup
-# This doesn't work right now.
-#@cbind  gli                 = @preset list
+@cbind  gli                 = @preset list
 
 # === Context menu items =====================================================
 

--- a/examples/data/scripts/session_list.sh
+++ b/examples/data/scripts/session_list.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+
+#dmenu.sh is a PITA with multiple-word prompts
+DMENU_PROMPT="Saved_sessions"
+. "$UZBL_UTIL_DIR/session_select.sh"
+

--- a/examples/data/scripts/session_open.sh
+++ b/examples/data/scripts/session_open.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+
+#dmenu.sh is a PITA with multiple-word prompts
+DMENU_PROMPT="Open_session"
+. "$UZBL_UTIL_DIR/session_select.sh"
+
+[ -n "$selection" ] && uzbl-tabbed -l "$selection"
+

--- a/examples/data/scripts/util/session_select.sh
+++ b/examples/data/scripts/util/session_select.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+DMENU_SCHEME="history"
+DMENU_OPTIONS="xmms vertical resize"
+
+. "$UZBL_UTIL_DIR/dmenu.sh"
+
+#NOTE: this is coupled to a specific implementation of
+#UzblTabbed.session_backup_filename, i.e. using dotfiles to hide the
+#backups
+selection="$( (uzbl-tabbed -L | grep -v '^\.') | $DMENU )"


### PR DESCRIPTION
As in the previous pull request, named sessions are files in config['saved_sessions_dir'], and there are bindings in the example config file.
In the command-line interface, flag '-l <name>' loads (opens) a new tabbed instance with the saved tabs in this session and '-L' lists the existing named sessions.
In uzbl-tabbed, dmenu is used to list and open existing sessions, while an actual argument is necessary for 'delete', 'save' (create a new named session from the current tabs in the browser) and 'merge' (which.. well, merges the current session with the one in the argument).
