### PR TITLE
Update README

### DIFF
--- a/README
+++ b/README
@@ -312,7 +312,7 @@ file).
 * `inject_html`: Inject an HTML string, navigating to the URI "about:blank" and
   rendering the HTML string given.
 * `geometry`: Geometry and position of the Uzbl window. Format is
-  "<width>x<height>+<x-offset>+<y-offset>".
+  "WidthxHeight+xOffset+yOffset".
 * `keycmd`: Holds the input buffer (callback: update input buffer).
 * `show_status`: Show statusbar or not.
 * `status_top`: statusbar on top?


### PR DESCRIPTION
Remove the < and > characters from the format description of the geometry variable.  In the website version of the README the geometry format displays as "x++" instead of "WidthxHeight+xOffset+yOffset" because of the < and > characters, despite what the DaringFireball Markdown docs say.  Other markup to signify that Width etcetera are placeholders for numeric values will probably not render sensibly in every output format, so that understanding requires intelligence from the reader.
