### PR TITLE
documentation of uzbl-tabbed in keybindings.html and minor html fix

### DIFF
--- a/docs/keybindings.html
+++ b/docs/keybindings.html
@@ -108,20 +108,20 @@
     <dt>l</dt>
     <dd>Scroll right</dd>
 
-    <dt>&lt;Page_Up></dt>
-    <dt>&lt;Ctrl>f</dt>
+    <dt>&lt;Page_Up&gt;</dt>
+    <dt>&lt;Ctrl&gt;f</dt>
     <dd>Page up</dd>
 
-    <dt>&lt;Page_Down></dt>
-    <dt>&lt;Ctrl>b</dt>
+    <dt>&lt;Page_Down&gt;</dt>
+    <dt>&lt;Ctrl&gt;b</dt>
     <dd>Page down</dd>
 
     <dt>&lt;&lt;</dt>
-    <dt>&lt;Home></dt>
+    <dt>&lt;Home&gt;</dt>
     <dd>Scroll to top</dd>
 
     <dt>&gt;&gt;</dt>
-    <dt>&lt;End></dt>
+    <dt>&lt;End&gt;</dt>
     <dd>Scroll to bottom</dd>
 
     <dt>/</dt>
@@ -151,12 +151,12 @@
   form input or the web page's keybindings.</p>
 
   <dl>
-    <dt>&lt;Ctrl>i</dt>
+    <dt>&lt;Ctrl&gt;i</dt>
     <dt>i</dt>
     <dd>Switch to insert mode</dd>
 
-    <dt>&lt;Escape></dt>
-    <dt>&lt;Ctrl>[</dt>
+    <dt>&lt;Escape&gt;</dt>
+    <dt>&lt;Ctrl&gt;[</dt>
     <dd>Return to command mode</dd>
     <dd>Clear the current command</dd>
   </dl>
@@ -238,7 +238,7 @@ set preset     <dd>event PRESET_TABS</dd>
     <dt>'p</dt>
     <dd>Open the URL in the primary selection in a new window</dd>
 
-    <dt class="long">&lt;Shift>&lt;Insert></dt>
+    <dt class="long">&lt;Shift&gt;&lt;Insert&gt;</dt>
     <dd>Command mode: Paste the primary selection into the status bar</dd>
     <dd>Insert mode:  Paste the primary selection into the active form
     element.</dd>
@@ -258,7 +258,7 @@ set preset     <dd>event PRESET_TABS</dd>
     <dt class="long">!reload</dt>
     <dd>Reload configuration file</dd>
 
-    <dt class="long">&lt;Ctrl>&lt;Mod1>t</dt>
+    <dt class="long">&lt;Ctrl&gt;&lt;Mod1&gt;t</dt>
     <dd>Open a terminal that prints events and can issue commands to uzbl</dd>
   </dl>
 </section>


### PR DESCRIPTION
In docs/keybindings.html:
- added uzbl-tabbed keybindings looking at the default config file
- Replaced all literal ">"s by "&amp;gt;"
