### PR TITLE
Remove reference to app_cache_directory variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -928,8 +928,6 @@ they are written as comments.
     `<width>x<height>+<xoffset>+<yoffset>` format.
 * `plugin_list` (string) (WebKit2 >= 1.11.4 or WebKit1 >= 1.3.8) (WebKit2 broken)
   - A JSON-formatted list describing loaded plugins.
-* `app_cache_directory` (string) (WebKit1 >= 1.3.13)
-  - Currently always `$XDG_CACHE_HOME/webkitgtk/applications`.
 * `uri` (string)
   - The current top-level URI of the view.
 * `embedded` (boolean)

--- a/src/variables.c
+++ b/src/variables.c
@@ -1366,11 +1366,6 @@ DECLARE_GETTER (gchar *, geometry);
 #ifdef HAVE_PLUGIN_API
 DECLARE_GETTER (gchar *, plugin_list);
 #endif
-#ifndef USE_WEBKIT2
-#if WEBKIT_CHECK_VERSION (1, 3, 13)
-DECLARE_GETTER (gchar *, app_cache_directory);
-#endif
-#endif
 DECLARE_GETTER (int, WEBKIT_MAJOR);
 DECLARE_GETTER (int, WEBKIT_MINOR);
 DECLARE_GETTER (int, WEBKIT_MICRO);
@@ -1712,11 +1707,6 @@ uzbl_variables_private_new (GHashTable *table)
         { "geometry",                     UZBL_C_FUNC (geometry,                               STR)},
 #ifdef HAVE_PLUGIN_API
         { "plugin_list",                  UZBL_C_FUNC (plugin_list,                            STR)},
-#endif
-#ifndef USE_WEBKIT2
-#if WEBKIT_CHECK_VERSION (1, 3, 13)
-        { "app_cache_directory",          UZBL_C_FUNC (app_cache_directory,                    STR)},
-#endif
 #endif
         { "uri",                          UZBL_C_STRING (uzbl.state.uri)},
         { "embedded",                     UZBL_C_INT (uzbl.state.plug_mode)},
@@ -3191,15 +3181,6 @@ mimetype_list_append (WebKitWebPluginMIMEType *mimetype, GString *list)
 
     g_string_append (list, "]}");
 }
-#endif
-
-#ifndef USE_WEBKIT2
-#if WEBKIT_CHECK_VERSION (1, 3, 13)
-IMPLEMENT_GETTER (gchar *, app_cache_directory)
-{
-    return g_strdup (webkit_application_cache_get_database_directory_path ());
-}
-#endif
 #endif
 
 IMPLEMENT_GETTER (int, WEBKIT_MAJOR)


### PR DESCRIPTION
This variable is sometimes corrupted in WebKit itself and cannot be
reliably retrieved.
