### PR TITLE
fix `toggle` command to use passed options

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -2605,7 +2605,7 @@ IMPLEMENT_COMMAND (toggle)
 
     guint i;
     for (i = 1; i < argv->len; ++i) {
-        const gchar *option = argv_idx (argv, 1);
+        const gchar *option = argv_idx (argv, i);
         uzbl_commands_args_append (toggle_args, g_strdup (option));
     }
 

--- a/src/variables.c
+++ b/src/variables.c
@@ -238,7 +238,7 @@ uzbl_variables_toggle (const gchar *name, GArray *values)
             guint i = 0;
             const gchar *first   = argv_idx (values, 0);
             const gchar *this    = first;
-                         next    = argv_idx (values, 1);
+                         next    = argv_idx (values, ++i);
 
             while (next && strcmp (current, this)) {
                 this = next;


### PR DESCRIPTION
make repeated `toggle` commands cycle through the string options passed,
as documented in README.

Previously issuing the command `toggle myvar one two three` would always set `myvar` to the value `one`, regardless of its previous value. 
