### PR TITLE
insert_bookmark.sh fails when zenity is called

### DIFF
--- a/examples/data/scripts/insert_bookmark.sh
+++ b/examples/data/scripts/insert_bookmark.sh
@@ -7,7 +7,7 @@
 
 which zenity >/dev/null 2>&1 || exit 2
 
-readonly entry="$( zenity --text="Add bookmark. add tags after the tabulators, separated by spaces" --entry-text="$UZBL_URI	$UZBL_TITLE	" )"
+readonly entry="$( zenity --entry --text="Add bookmark. add tags after the tabulators, separated by spaces" --entry-text="$UZBL_URI	$UZBL_TITLE	" )"
 readonly exitstatus="$?"
 [ "$exitstatus" -eq 0 ] || exit "$exitstatus"
 


### PR DESCRIPTION
without dialog type.

That leads to messed up bookmarks file.
Fix it by passing "--entry" to zenity.