### PR TITLE
Create WebKitWebView with webkit_web_view_new_with_user_content_manager

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -97,10 +97,6 @@ uzbl_gui_free ()
         g_object_unref (uzbl.gui_->tmp_web_view);
     }
 
-/*#if WEBKIT_CHECK_VERSION (2, 6, 0)
-    g_free(uzbl.gui.user_manager);
-#endif*/
-
     g_free (uzbl.gui_);
     uzbl.gui_ = NULL;
 }

--- a/src/gui.c
+++ b/src/gui.c
@@ -97,6 +97,10 @@ uzbl_gui_free ()
         g_object_unref (uzbl.gui_->tmp_web_view);
     }
 
+/*#if WEBKIT_CHECK_VERSION (2, 6, 0)
+    g_free(uzbl.gui.user_manager);
+#endif*/
+
     g_free (uzbl.gui_);
     uzbl.gui_ = NULL;
 }
@@ -290,7 +294,13 @@ scroll_horiz_cb (GtkAdjustment *adjust, gpointer data);
 void
 web_view_init ()
 {
+#if WEBKIT_CHECK_VERSION (2, 6, 0)
+    uzbl.gui.user_manager = webkit_user_content_manager_new ();
+    uzbl.gui.web_view = WEBKIT_WEB_VIEW (
+          webkit_web_view_new_with_user_content_manager(uzbl.gui.user_manager));
+#else
     uzbl.gui.web_view = WEBKIT_WEB_VIEW (webkit_web_view_new ());
+#endif
     uzbl.gui.scrolled_win = gtk_scrolled_window_new (NULL, NULL);
 
     gtk_container_add (

--- a/src/gui.c
+++ b/src/gui.c
@@ -294,7 +294,7 @@ scroll_horiz_cb (GtkAdjustment *adjust, gpointer data);
 void
 web_view_init ()
 {
-#if WEBKIT_CHECK_VERSION (2, 6, 0)
+#if defined(USE_WEBKIT2) && WEBKIT_CHECK_VERSION (2, 5, 1)
     uzbl.gui.user_manager = webkit_user_content_manager_new ();
     uzbl.gui.web_view = WEBKIT_WEB_VIEW (
           webkit_web_view_new_with_user_content_manager(uzbl.gui.user_manager));

--- a/src/uzbl-core.h
+++ b/src/uzbl-core.h
@@ -28,7 +28,7 @@ typedef struct {
     WebKitWebView *web_view;
     gchar         *main_title;
 
-#if WEBKIT_CHECK_VERSION (2, 6, 0)
+#if defined(USE_WEBKIT2) && WEBKIT_CHECK_VERSION (2, 5, 1)
     WebKitUserContentManager *user_manager;
 #endif
 

--- a/src/uzbl-core.h
+++ b/src/uzbl-core.h
@@ -28,6 +28,10 @@ typedef struct {
     WebKitWebView *web_view;
     gchar         *main_title;
 
+#if WEBKIT_CHECK_VERSION (2, 6, 0)
+    WebKitUserContentManager *user_manager;
+#endif
+
     /* Inspector */
     WebKitWebInspector *inspector;
 


### PR DESCRIPTION
According to the webkit docs, WebKitWebView only has a user_content_manager if it's created using webkit_web_view_new_with_user_content_manager

Creating the view without this breaks the script command, which needs the content manager to load scripts.