### PR TITLE
webkit_user_content_manager_(un)register_script_message_handler is from webkit 2.8 or later

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -1931,7 +1931,9 @@ IMPLEMENT_COMMAND (script)
             NULL);
         g_free (signal_name);
 
+#if WEBKIT_CHECK_VERSION (2, 8, 0)
         webkit_user_content_manager_register_script_message_handler (manager, name);
+#endif
 
         g_hash_table_insert (uzbl.commands->script_handler_data_table, g_strdup (name), handler_data);
     } else if (!g_strcmp0 (command, "ignore")) {
@@ -1945,7 +1947,9 @@ IMPLEMENT_COMMAND (script)
             return;
         }
 
+#if WEBKIT_CHECK_VERSION (2, 8, 0)
         webkit_user_content_manager_unregister_script_message_handler (manager, name);
+#endif
 
         gchar *signal_name = g_strdup_printf ("signal::script-message-handler::%s",
             name);


### PR DESCRIPTION
According to the webkit documentation, webkit_user_content_manager_register_script_message_handler is only supported from 2.8 onwards, and this breaks compilation with earlier webkit releases.

This protects these calls with appropriate WEBKIT_CHECK_VERSION checks