### PR TITLE
Add webkit2 js callback

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -2592,9 +2592,17 @@ IMPLEMENT_COMMAND (inspector)
 
 /* Execution commands */
 
+#ifdef USE_WEBKIT2
+static void
+run_js_callback (GObject *object, GAsyncResult *result, gpointer data);
+#endif
+
 IMPLEMENT_COMMAND (js)
 {
     ARG_CHECK (argv, 3);
+#ifdef USE_WEBKIT2
+    UZBL_UNUSED (result);
+#endif
 
     const gchar *context = argv_idx (argv, 0);
     const gchar *where = argv_idx (argv, 1);
@@ -2677,6 +2685,10 @@ IMPLEMENT_COMMAND (js)
         goto js_exit;
     }
 
+#ifdef USE_WEBKIT2
+    webkit_web_view_run_javascript(uzbl.gui.web_view, script, NULL,
+                                   run_js_callback, NULL);
+#else
     JSObjectRef globalobject = JSContextGetGlobalObject (jsctx);
     JSValueRef js_exc = NULL;
 
@@ -2706,6 +2718,7 @@ IMPLEMENT_COMMAND (js)
 
     JSStringRelease (js_file);
     JSStringRelease (js_script);
+#endif
 
     g_free (script);
     g_free (path);
@@ -3081,6 +3094,34 @@ script_message_callback (WebKitUserContentManager *manager, WebKitJavascriptResu
     g_free (res_str);
 }
 #endif
+
+void
+run_js_callback (GObject *object, GAsyncResult *result, gpointer data)
+{
+    WebKitJavascriptResult *res;
+    GError *error = NULL;
+
+    res = webkit_web_view_run_javascript_finish (WEBKIT_WEB_VIEW (object),
+                                                       result, &error);
+    if (!res) {
+       uzbl_debug ("Error running javascript:\n %s\n", error->message);
+       g_error_free (error);
+       return;
+    }
+
+    JSGlobalContextRef ctx = webkit_javascript_result_get_global_context (res);
+    JSValueRef res_val = webkit_javascript_result_get_value (res);
+    gchar *res_str = uzbl_js_to_string (ctx, res_val);
+
+    uzbl_events_send (JS_MESSAGE, NULL,
+        TYPE_STR, "javascript",
+        TYPE_STR, res_str,
+        NULL);
+
+    g_free (res_str);
+    webkit_javascript_result_unref (res);
+}
+
 #endif
 
 void

--- a/src/commands.c
+++ b/src/commands.c
@@ -3104,7 +3104,10 @@ run_js_callback (GObject *object, GAsyncResult *result, gpointer data)
     res = webkit_web_view_run_javascript_finish (WEBKIT_WEB_VIEW (object),
                                                        result, &error);
     if (!res) {
-       uzbl_debug ("Error running javascript:\n %s\n", error->message);
+        uzbl_events_send (JS_MESSAGE, NULL,
+            TYPE_STR, "error",
+            TYPE_STR, error->message,
+            NULL);
        g_error_free (error);
        return;
     }

--- a/src/events.h
+++ b/src/events.h
@@ -56,6 +56,7 @@
     call (WEB_PROCESS_STARTED), \
     call (TLS_ERROR),           \
     call (SCRIPT_MESSAGE),      \
+    call (JS_MESSAGE),          \
     /* Must be last entry. */   \
     call (LAST_EVENT)
 


### PR DESCRIPTION
This uses webkit_web_view_run_javascript and a suitable callback function to handle the "js" command, which appears to be the correct approach to doing this with WebKit2.

Currently, this breaks the use of javascript variables since the js command no longer returns the results. I'm not certain of how best to go about fixing that.
