### PR TITLE
include system python packages in sandbox

### DIFF
--- a/DEBUGGING.md
+++ b/DEBUGGING.md
@@ -64,3 +64,13 @@ Minimal test cases are very useful and can be made using custom configuration
 files passed to uzbl via the `-c` flag. Coupled with `--named` to get a
 predictable socket name, commands can be sent using a program or text file. When
 reporting bugs, these can help immensely in finding problems.
+
+Sandbox
+-------
+
+The Makefile contains special build targets to install and run the local build
+in a isolated environment dubbed the sandbox. `virtualenv` is used to create
+the python environment for the sandbox and will need to be installed on your
+system.
+
+To start uzbl in the sandbox use ```make test-uzbl-browser-sandbox```

--- a/Makefile
+++ b/Makefile
@@ -189,14 +189,14 @@ test-uzbl-browser-sandbox: sandbox uzbl-browser sandbox-install-uzbl-browser san
 	rm -rf ./sandbox/usr
 
 test-uzbl-tabbed-sandbox: sandbox uzbl-browser sandbox-install-uzbl-browser sandbox-install-uzbl-tabbed sandbox-install-example-data
-	./sandbox/env.sh ${PYTHON} -S sandbox/usr/bin/uzbl-event-manager restart -avv
+	./sandbox/env.sh ${PYTHON} sandbox/usr/bin/uzbl-event-manager restart -avv
 	./sandbox/env.sh uzbl-tabbed
-	./sandbox/env.sh ${PYTHON} -S sandbox/usr/bin/uzbl-event-manager stop -avv
+	./sandbox/env.sh ${PYTHON} sandbox/usr/bin/uzbl-event-manager stop -avv
 	make DESTDIR=./sandbox uninstall
 	rm -rf ./sandbox/usr
 
 test-uzbl-event-manager-sandbox: sandbox uzbl-browser sandbox-install-uzbl-browser sandbox-install-example-data
-	./sandbox/env.sh ${PYTHON} -S sandbox/usr/bin/uzbl-event-manager restart -navv
+	./sandbox/env.sh ${PYTHON} sandbox/usr/bin/uzbl-event-manager restart -navv
 	make DESTDIR=./sandbox uninstall
 	rm -rf ./sandbox/usr
 
@@ -219,9 +219,11 @@ SANDBOXOPTS=\
 	DESTDIR=./sandbox \
 	PREFIX=/usr \
 	RUN_PREFIX=`pwd`/sandbox/usr \
-	PYINSTALL_EXTRA='--prefix=./usr --install-scripts=./usr/bin'
+	PYINSTALL_EXTRA='--prefix=./ --install-scripts=./usr/bin'
 
 sandbox: misc/env.sh
+	virtualenv -p$(PYTHON) sandbox
+	. sandbox/bin/activate ; pip install six
 	mkdir -p sandbox/usr/lib64
 	cp -p misc/env.sh sandbox/env.sh
 	test -e sandbox/usr/lib || ln -s lib64 sandbox/usr/lib

--- a/misc/env.sh
+++ b/misc/env.sh
@@ -29,12 +29,6 @@ export XDG_CONFIG_HOME
 PATH="$( pwd )/sandbox/usr/bin:$PATH"
 export PATH
 
-PYTHONLIB=$( python3 -c 'from distutils.sysconfig import get_python_lib; print(get_python_lib(prefix="/usr"))' )
-
-UZBL_PLUGIN_PATH="$( pwd )/sandbox/$PYTHONLIB/uzbl/plugins"
-export UZBL_PLUGIN_PATH
-
-PYTHONPATH="$( pwd )/sandbox/$PYTHONLIB/"
-export PYTHONPATH
+. sandbox/bin/activate
 
 exec "$@"


### PR DESCRIPTION
This makes it possible to load the system wide installed six library
while still preferring the uzbl modules installed into the sandbox