### PR TITLE
run event manager tests on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+python:
+    - "2.7"
+    - "3.3"
+    - "3.4"
+    - "pypy"
+install:
+    - pip install six nose mock coveralls
+script:
+    nosetests tests/event-manager --with-coverage --cover-package=uzbl
+after_success:
+    coveralls
+sudo: false

--- a/tests/event-manager/emtest.py
+++ b/tests/event-manager/emtest.py
@@ -1,0 +1,30 @@
+from mock import Mock
+import logging
+from uzbl.event_manager import Uzbl
+
+
+class EventManagerMock(object):
+    def __init__(self,
+        global_plugins=(), instance_plugins=(),
+        global_mock_plugins=(), instance_mock_plugins=()
+    ):
+        self.uzbls = {}
+        self.plugins = {}
+        self.instance_plugins = instance_plugins
+        self.instance_mock_plugins = instance_mock_plugins
+        for plugin in global_plugins:
+            self.plugins[plugin] = plugin(self)
+        for (plugin, mock) in global_mock_plugins:
+            self.plugins[plugin] = mock() if mock else Mock(plugin)
+
+    def add(self):
+        u = Mock(spec=Uzbl)
+        u.parent = self
+        u.logger = logging.getLogger('debug')
+        u.plugins = {}
+        for plugin in self.instance_plugins:
+            u.plugins[plugin] = plugin(u)
+        for (plugin, mock) in self.instance_mock_plugins:
+            u.plugins[plugin] = mock() if mock else Mock(plugin)
+        self.uzbls[Mock()] = u
+        return u

--- a/tests/event-manager/testarguments.py
+++ b/tests/event-manager/testarguments.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+import unittest
+from uzbl.arguments import Arguments
+
+
+class ArgumentsTest(unittest.TestCase):
+    def test_empty(self):
+        a = Arguments('')
+        self.assertEqual(len(a), 0)
+        self.assertEqual(a.raw(), '')
+
+    def test_space(self):
+        a = Arguments(' foo  bar')
+        self.assertEqual(len(a), 2)
+        self.assertEqual(a.raw(), 'foo  bar')
+        self.assertEqual(a.raw(0, 0), 'foo')
+        self.assertEqual(a.raw(1, 1), 'bar')
+
+    def test_tab(self):
+        a = Arguments('\tfoo\t\tbar')
+        self.assertEqual(len(a), 2)
+        self.assertEqual(a.raw(), 'foo\t\tbar')
+        self.assertEqual(a.raw(0, 0), 'foo')
+        self.assertEqual(a.raw(1, 1), 'bar')

--- a/tests/event-manager/testbind.py
+++ b/tests/event-manager/testbind.py
@@ -1,0 +1,51 @@
+#!/usr/bin/env python
+
+
+import sys
+if '' not in sys.path:
+    sys.path.insert(0, '')
+
+import mock
+import unittest
+from emtest import EventManagerMock
+from uzbl.plugins.bind import Bind, BindPlugin
+from uzbl.plugins.config import Config
+
+
+def justafunction():
+    pass
+
+
+class BindTest(unittest.TestCase):
+    def test_unique_id(self):
+        a = Bind('spam', 'spam')
+        b = Bind('spam', 'spam')
+        self.assertNotEqual(a.bid, b.bid)
+
+
+class BindPluginTest(unittest.TestCase):
+    def setUp(self):
+        self.event_manager = EventManagerMock((), (Config, BindPlugin))
+        self.uzbl = self.event_manager.add()
+
+    def test_add_bind(self):
+        b = BindPlugin[self.uzbl]
+        modes = 'global'
+        glob = 'test'
+        handler = justafunction
+        b.mode_bind(modes, glob, handler)
+
+        binds = b.bindlet.get_binds()
+        self.assertEqual(len(binds), 1)
+        self.assertIs(binds[0].function, justafunction)
+
+    def test_parse_bind(self):
+        b = BindPlugin[self.uzbl]
+        modes = 'global'
+        glob = 'test'
+        handler = 'handler'
+
+        b.parse_mode_bind('%s %s = %s' % (modes, glob, handler))
+        binds = b.bindlet.get_binds()
+        self.assertEqual(len(binds), 1)
+        self.assertEqual(binds[0].commands, [handler])

--- a/tests/event-manager/testcompletion.py
+++ b/tests/event-manager/testcompletion.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python
+# vi: set et ts=4:
+
+
+
+import unittest
+from emtest import EventManagerMock
+from uzbl.plugins.config import Config
+from uzbl.plugins.keycmd import KeyCmd
+from uzbl.plugins.completion import CompletionPlugin
+
+
+class DummyFormatter(object):
+    def format(self, partial, completions):
+        return '[%s] %s' % (partial, ', '.join(completions))
+
+class TestAdd(unittest.TestCase):
+    def setUp(self):
+        self.event_manager = EventManagerMock(
+            (), (CompletionPlugin,),
+            (), ((Config, dict), (KeyCmd, None))
+        )
+        self.uzbl = self.event_manager.add()
+
+    def test_builtins(self):
+        c = CompletionPlugin[self.uzbl]
+        c.add_builtins(('spam', 'egg'))
+        self.assertIn('spam', c.completion)
+        self.assertIn('egg', c.completion)
+
+    def test_config(self):
+        c = CompletionPlugin[self.uzbl]
+        c.add_config_key('spam', 'SPAM')
+        self.assertIn('@spam', c.completion)
+
+
+class TestCompletion(unittest.TestCase):
+    def setUp(self):
+        self.event_manager = EventManagerMock(
+            (), (KeyCmd, CompletionPlugin),
+            (), ((Config, dict),)
+        )
+        self.uzbl = self.event_manager.add()
+
+        c = CompletionPlugin[self.uzbl]
+        c.listformatter = DummyFormatter()
+        c.add_builtins(('spam', 'egg', 'bar', 'baz'))
+        c.add_config_key('spam', 'SPAM')
+        c.add_config_key('Something', 'Else')
+
+    def test_incomplete_keyword(self):
+        k, c = KeyCmd[self.uzbl], CompletionPlugin[self.uzbl]
+        k.keylet.keycmd = 'sp'
+        k.keylet.cursor = len(k.keylet.keycmd)
+
+        r = c.get_incomplete_keyword()
+        self.assertEqual(r, ('sp', False))
+
+    def test_incomplete_keyword_var(self):
+        k, c = KeyCmd[self.uzbl], CompletionPlugin[self.uzbl]
+        k.keylet.keycmd = 'set @sp'
+        k.keylet.cursor = len(k.keylet.keycmd)
+
+        r = c.get_incomplete_keyword()
+        self.assertEqual(r, ('@sp', False))
+
+    def test_incomplete_keyword_var_noat(self):
+        k, c = KeyCmd[self.uzbl], CompletionPlugin[self.uzbl]
+        k.keylet.keycmd = 'set Some'
+        k.keylet.cursor = len(k.keylet.keycmd)
+
+        r = c.get_incomplete_keyword()
+        self.assertEqual(r, ('@Some', True))
+
+    def test_stop_completion(self):
+        config, c = Config[self.uzbl], CompletionPlugin[self.uzbl]
+        c.completion.level = 99
+        config['completion_list'] = 'test'
+
+        c.stop_completion()
+        self.assertNotIn('completion_list', config)
+        self.assertEqual(c.completion.level, 0)
+
+    def test_completion(self):
+        k, c = KeyCmd[self.uzbl], CompletionPlugin[self.uzbl]
+        config = Config[self.uzbl]
+
+        comp = (
+            ('sp', 'spam '),
+            ('e', 'egg '),
+            ('set @sp', 'set @spam '),
+        )
+
+        for i, o in comp:
+            k.keylet.keycmd = i
+            k.keylet.cursor = len(k.keylet.keycmd)
+
+            c.start_completion()
+            self.assertEqual(k.keylet.keycmd, o)
+            c.start_completion()
+            self.assertNotIn('completion_list', config)
+
+    def test_completion_list(self):
+        k, c = KeyCmd[self.uzbl], CompletionPlugin[self.uzbl]
+        config = Config[self.uzbl]
+
+        comp = (
+            ('b', 'ba', '[ba] bar, baz'),
+        )
+
+        for i, o, l in comp:
+            k.keylet.keycmd = i
+            k.keylet.cursor = len(k.keylet.keycmd)
+
+            c.start_completion()
+            self.assertEqual(k.keylet.keycmd, o)
+            c.start_completion()
+            self.assertEqual(config['completion_list'], l)

--- a/tests/event-manager/testcompletion.py
+++ b/tests/event-manager/testcompletion.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # vi: set et ts=4:
 
-
-
 import unittest
 from emtest import EventManagerMock
 from uzbl.plugins.config import Config
@@ -12,7 +10,8 @@ from uzbl.plugins.completion import CompletionPlugin
 
 class DummyFormatter(object):
     def format(self, partial, completions):
-        return '[%s] %s' % (partial, ', '.join(completions))
+        return '[%s] %s' % (partial, ', '.join(sorted(completions)))
+
 
 class TestAdd(unittest.TestCase):
     def setUp(self):
@@ -24,7 +23,7 @@ class TestAdd(unittest.TestCase):
 
     def test_builtins(self):
         c = CompletionPlugin[self.uzbl]
-        c.add_builtins(('spam', 'egg'))
+        c.add_builtins('["spam", "egg"]')
         self.assertIn('spam', c.completion)
         self.assertIn('egg', c.completion)
 
@@ -44,7 +43,7 @@ class TestCompletion(unittest.TestCase):
 
         c = CompletionPlugin[self.uzbl]
         c.listformatter = DummyFormatter()
-        c.add_builtins(('spam', 'egg', 'bar', 'baz'))
+        c.add_builtins('["spam", "egg", "bar", "baz"]')
         c.add_config_key('spam', 'SPAM')
         c.add_config_key('Something', 'Else')
 
@@ -54,7 +53,7 @@ class TestCompletion(unittest.TestCase):
         k.keylet.cursor = len(k.keylet.keycmd)
 
         r = c.get_incomplete_keyword()
-        self.assertEqual(r, ('sp', False))
+        self.assertEqual(r, 'sp')
 
     def test_incomplete_keyword_var(self):
         k, c = KeyCmd[self.uzbl], CompletionPlugin[self.uzbl]
@@ -62,7 +61,7 @@ class TestCompletion(unittest.TestCase):
         k.keylet.cursor = len(k.keylet.keycmd)
 
         r = c.get_incomplete_keyword()
-        self.assertEqual(r, ('@sp', False))
+        self.assertEqual(r, '@sp')
 
     def test_incomplete_keyword_var_noat(self):
         k, c = KeyCmd[self.uzbl], CompletionPlugin[self.uzbl]
@@ -70,7 +69,7 @@ class TestCompletion(unittest.TestCase):
         k.keylet.cursor = len(k.keylet.keycmd)
 
         r = c.get_incomplete_keyword()
-        self.assertEqual(r, ('@Some', True))
+        self.assertEqual(r, '@Some')
 
     def test_stop_completion(self):
         config, c = Config[self.uzbl], CompletionPlugin[self.uzbl]

--- a/tests/event-manager/testconfig.py
+++ b/tests/event-manager/testconfig.py
@@ -22,7 +22,7 @@ class ConfigTest(unittest.TestCase):
         for input, expected in cases:
             c.set('foo', input)
             self.uzbl.send.assert_called_once_with(
-                'set foo = ' + expected)
+                'set foo ' + expected)
             self.uzbl.send.reset_mock()
 
     def test_set_invalid(self):
@@ -38,7 +38,7 @@ class ConfigTest(unittest.TestCase):
         cases = (
             ('foo str value', 'foo', 'value'),
             ('foo str "ba ba"', 'foo', 'ba ba'),
-            ('foo float 5', 'foo', 5.0)
+            ('foo double 5', 'foo', 5.0)
         )
         c = Config[self.uzbl]
         for input, ekey, evalue in cases:

--- a/tests/event-manager/testconfig.py
+++ b/tests/event-manager/testconfig.py
@@ -1,0 +1,77 @@
+
+
+import unittest
+from emtest import EventManagerMock
+
+from uzbl.plugins.config import Config
+
+
+class ConfigTest(unittest.TestCase):
+    def setUp(self):
+        self.event_manager = EventManagerMock((), (Config,))
+        self.uzbl = self.event_manager.add()
+
+    def test_set(self):
+        cases = (
+            (True, '1'),
+            (False, '0'),
+            ("test", "test"),
+            (5, '5')
+        )
+        c = Config[self.uzbl]
+        for input, expected in cases:
+            c.set('foo', input)
+            self.uzbl.send.assert_called_once_with(
+                'set foo = ' + expected)
+            self.uzbl.send.reset_mock()
+
+    def test_set_invalid(self):
+        cases = (
+            ("foo\nbar", AssertionError),  # Better Exception type
+            ("bad'key", AssertionError)
+        )
+        c = Config[self.uzbl]
+        for input, exception in cases:
+            self.assertRaises(exception, c.set, input)
+
+    def test_parse(self):
+        cases = (
+            ('foo str value', 'foo', 'value'),
+            ('foo str "ba ba"', 'foo', 'ba ba'),
+            ('foo float 5', 'foo', 5.0)
+        )
+        c = Config[self.uzbl]
+        for input, ekey, evalue in cases:
+            c.parse_set_event(input)
+            self.assertIn(ekey, c)
+            self.assertEqual(c[ekey], evalue)
+            self.uzbl.event.assert_called_once_with(
+                'CONFIG_CHANGED', ekey, evalue)
+            self.uzbl.event.reset_mock()
+
+    def test_parse_null(self):
+        cases = (
+            ('foo str', 'foo'),
+            ('foo str ""', 'foo'),
+            #('foo int', 'foo')  # Not sure if this input is valid
+        )
+        c = Config[self.uzbl]
+        for input, ekey in cases:
+            c.update({'foo': '-'})
+            c.parse_set_event(input)
+            self.assertNotIn(ekey, c)
+            self.uzbl.event.assert_called_once_with(
+                'CONFIG_CHANGED', ekey, '')
+            self.uzbl.event.reset_mock()
+
+    def test_parse_invalid(self):
+        cases = (
+            ('foo bar', AssertionError),  # TypeError?
+            ('foo bad^key', AssertionError),
+            ('', Exception),
+            ('foo int z', ValueError)
+        )
+        c = Config[self.uzbl]
+        for input, exception in cases:
+            self.assertRaises(exception, c.parse_set_event, input)
+            self.assertEqual(len(list(c.keys())), 0)

--- a/tests/event-manager/testcookie.py
+++ b/tests/event-manager/testcookie.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python
+
+
+import sys
+if '' not in sys.path:
+    sys.path.insert(0, '')
+
+import unittest
+from emtest import EventManagerMock
+
+from uzbl.plugins.cookies import Cookies
+
+cookies = (
+    r'".nyan.cat" "/" "__utmb" "183192761.1.10.1313990640" "http" "1313992440"',
+    r'".twitter.com" "/" "guest_id" "v1%3A131399064036991891" "http" "1377104460"'
+)
+
+
+class CookieFilterTest(unittest.TestCase):
+    def setUp(self):
+        self.event_manager = EventManagerMock((), (Cookies,))
+        self.uzbl = self.event_manager.add()
+        self.other = self.event_manager.add()
+
+    def test_add_cookie(self):
+        c = Cookies[self.uzbl]
+        c.add_cookie(cookies[0])
+        self.other.send.assert_called_once_with(
+            'add_cookie ' + cookies[0])
+
+    def test_whitelist_block(self):
+        c = Cookies[self.uzbl]
+        c.whitelist_cookie(r'domain "nyan\.cat$"')
+        c.add_cookie(cookies[1])
+        self.uzbl.send.assert_called_once_with(
+            'delete_cookie ' + cookies[1])
+
+    def test_whitelist_accept(self):
+        c = Cookies[self.uzbl]
+        c.whitelist_cookie(r'domain "nyan\.cat$"')
+        c.add_cookie(cookies[0])
+        self.other.send.assert_called_once_with(
+            'add_cookie ' + cookies[0])
+
+    def test_blacklist_block(self):
+        c = Cookies[self.uzbl]
+        c.blacklist_cookie(r'domain "twitter\.com$"')
+        c.add_cookie(cookies[1])
+        self.uzbl.send.assert_called_once_with(
+            'delete_cookie ' + cookies[1])
+
+    def test_blacklist_accept(self):
+        c = Cookies[self.uzbl]
+        c.blacklist_cookie(r'domain "twitter\.com$"')
+        c.add_cookie(cookies[0])
+        self.other.send.assert_called_once_with(
+            'add_cookie ' + cookies[0])
+
+    def test_filter_numeric(self):
+        c = Cookies[self.uzbl]
+        c.blacklist_cookie(r'0 "twitter\.com$"')
+        c.add_cookie(cookies[1])
+        self.uzbl.send.assert_called_once_with(
+            'delete_cookie ' + cookies[1])
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/event-manager/testcore.py
+++ b/tests/event-manager/testcore.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python
+# vi: set et ts=4:
+
+
+
+import unittest
+from mock import Mock
+from uzbl.core import Uzbl
+
+
+class TestUzbl(unittest.TestCase):
+    def setUp(self):
+        options = Mock()
+        options.print_events = False
+        self.em = Mock()
+        self.proto = Mock()
+        self.uzbl = Uzbl(self.em, self.proto, options)
+
+    def test_repr(self):
+        r = '%r' % self.uzbl
+        self.assertRegex(r, r'<uzbl\(.*\)>')
+
+    def test_event_handler(self):
+        handler = Mock()
+        event, arg = 'FOO', 'test'
+        self.uzbl.connect(event, handler)
+        self.uzbl.event(event, arg)
+        handler.assert_called_once_with(arg)
+
+    def test_parse_sets_name(self):
+        name = 'spam'
+        self.uzbl.parse_msg(' '.join(['EVENT', name, 'FOO', 'BAR']))
+        self.assertEqual(self.uzbl.name, name)
+
+    def test_parse_sends_event(self):
+        handler = Mock()
+        event, arg = 'FOO', 'test'
+        self.uzbl.connect(event, handler)
+        self.uzbl.parse_msg(' '.join(['EVENT', 'instance-name', event, arg]))
+        handler.assert_called_once_with(arg)
+
+    def test_malformed_message(self):
+        # Should not crash
+        self.uzbl.parse_msg('asdaf')
+        self.assertTrue(True)
+
+    def test_send(self):
+        self.uzbl.send('hello  ')
+        self.proto.push.assert_called_once_with('hello\n'.encode('utf-8'))
+
+    def test_close_calls_remove_instance(self):
+        self.uzbl.close()
+        self.em.remove_instance.assert_called_once_with(self.proto.socket)
+
+    def test_close_cleans_plugins(self):
+        p1, p2 = Mock(), Mock()
+        self.uzbl._plugin_instances = (p1, p2)
+        self.uzbl.plugins = {}
+        self.uzbl.close()
+        p1.cleanup.assert_called_once_with()
+        p2.cleanup.assert_called_once_with()
+
+    def test_close_connection_closes_protocol(self):
+        self.uzbl.close_connection(Mock())
+        self.proto.close.assert_called_once_with()
+
+    def test_exit_triggers_close(self):
+        self.uzbl.parse_msg(' '.join(['EVENT', 'spam', 'INSTANCE_EXIT']))
+        self.em.remove_instance.assert_called_once_with(self.proto.socket)
+
+    def test_instance_start(self):
+        pid = 1234
+        self.em.plugind.per_instance_plugins = []
+        self.uzbl.parse_msg(
+            ' '.join(['EVENT', 'spam', 'INSTANCE_START', str(pid)])
+        )
+        self.assertEqual(self.uzbl.pid, pid)
+
+    def test_init_plugins(self):
+        u = self.uzbl
+        class FooPlugin(object):
+            def __init__(self, uzbl): pass
+        class BarPlugin(object):
+            def __init__(self, uzbl): pass
+        self.em.plugind.per_instance_plugins = [FooPlugin, BarPlugin]
+        u.init_plugins()
+        self.assertEqual(len(u.plugins), 2)
+        for t in (FooPlugin, BarPlugin):
+            self.assertIn(t, u.plugins)
+            self.assertTrue(isinstance(u.plugins[t], t))

--- a/tests/event-manager/testcore.py
+++ b/tests/event-manager/testcore.py
@@ -1,8 +1,7 @@
 #!/usr/bin/env python
 # vi: set et ts=4:
 
-
-
+import six
 import unittest
 from mock import Mock
 from uzbl.core import Uzbl
@@ -18,7 +17,7 @@ class TestUzbl(unittest.TestCase):
 
     def test_repr(self):
         r = '%r' % self.uzbl
-        self.assertRegex(r, r'<uzbl\(.*\)>')
+        six.assertRegex(self, r, r'<uzbl\(.*\)>')
 
     def test_event_handler(self):
         handler = Mock()

--- a/tests/event-manager/testdoc.py
+++ b/tests/event-manager/testdoc.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python
+# vi: set et ts=4:
+
+import sys
+if '' not in sys.path:
+    sys.path.insert(0, '')
+
+import unittest
+from doctest import DocTestSuite
+keycmd_tests = DocTestSuite('uzbl.plugins.keycmd')
+arguments_tests = DocTestSuite('uzbl.arguments')
+
+
+def load_tests(loader, standard, pattern):
+    tests = unittest.TestSuite()
+    tests.addTest(keycmd_tests)
+    tests.addTest(arguments_tests)
+    return tests
+
+if __name__ == '__main__':
+    runner = unittest.TextTestRunner()
+    runner.run()

--- a/tests/event-manager/testdownload.py
+++ b/tests/event-manager/testdownload.py
@@ -1,0 +1,29 @@
+# vi: set et ts=4:
+
+
+
+import unittest
+from emtest import EventManagerMock
+
+from uzbl.plugins.config import Config
+from uzbl.plugins.downloads import Downloads
+
+
+class DownloadsTest(unittest.TestCase):
+    def setUp(self):
+        self.event_manager = EventManagerMock((), (Downloads, Config))
+        self.uzbl = self.event_manager.add()
+
+    def test_start(self):
+        cases = (
+            ('foo', 'foo', 'foo (0%)'),
+            ('"b@r"', 'b@r', 'b@r (0%'),
+        )
+        d = Downloads[self.uzbl]
+        for input, key, section in cases:
+            d.download_started(input)
+            self.assertIn(key, d.active_downloads)
+            self.assertEqual(d.active_downloads[key], 0)
+            self.uzbl.send.assert_called_once()
+            self.assertIn(section, self.uzbl.send.call_args[0][0])
+            self.uzbl.reset_mock()

--- a/tests/event-manager/testhistory.py
+++ b/tests/event-manager/testhistory.py
@@ -1,0 +1,154 @@
+#!/usr/bin/env python
+# vi: set et ts=4:
+
+
+
+import sys
+if '' not in sys.path:
+    sys.path.insert(0, '')
+
+import unittest
+from emtest import EventManagerMock
+
+from uzbl.plugins.history import History, SharedHistory
+from uzbl.plugins.keycmd import Keylet, KeyCmd
+from uzbl.plugins.on_set import OnSetPlugin
+from uzbl.plugins.config import Config
+
+
+class SharedHistoryTest(unittest.TestCase):
+    def setUp(self):
+        self.event_manager = EventManagerMock((SharedHistory,), ())
+        self.uzbl = self.event_manager.add()
+        self.other = self.event_manager.add()
+
+    def test_instance(self):
+        a = SharedHistory[self.uzbl]
+        b = SharedHistory[self.other]
+        self.assertIs(a, b)
+
+    def test_add_and_get(self):
+        s = SharedHistory[self.uzbl]
+        s.addline('foo', 'bar')
+        s.addline('foo', 'baz')
+        s.addline('foo', 'bap')
+        self.assertEqual(s.get_line_number('foo'), 3)
+        self.assertEqual(s.get_line_number('other'), 0)
+        self.assertEqual(s.getline('foo', 0), 'bar')
+        self.assertEqual(s.getline('foo', 1), 'baz')
+        self.assertEqual(s.getline('foo', 2), 'bap')
+        self.assertEqual(s.getline('foo', -1), 'bap')
+
+    def test_empty_line_number(self):
+        s = SharedHistory[self.uzbl]
+        s.addline('foo', 'bar')
+        self.assertEqual(s.get_line_number(''), 0)
+        self.assertEqual(s.get_line_number('other'), 0)
+
+    def test_get_missing_prompt(self):
+        s = SharedHistory[self.uzbl]
+        s.addline('foo', 'bar')
+        self.assertRaises(IndexError, s.getline, 'bar', 0)
+
+
+class HistoryTest(unittest.TestCase):
+    def setUp(self):
+        self.event_manager = EventManagerMock(
+            (SharedHistory,),
+            (OnSetPlugin, KeyCmd, Config, History)
+        )
+        self.uzbl = self.event_manager.add()
+        self.other = self.event_manager.add()
+        s = SharedHistory[self.uzbl]
+        data = (
+            ('', 'woop'),
+            ('', 'doop'),
+            ('', 'bar'),
+            ('', 'foo'),
+            ('git', 'spam'),
+            ('git', 'egg'),
+            ('foo', 'foo')
+        )
+        for prompt, input in data:
+            s.addline(prompt, input)
+
+    def test_step(self):
+        h = History[self.uzbl]
+        self.assertEqual('', next(h))
+        self.assertEqual('', next(h))
+        self.assertEqual('foo', h.prev())
+        self.assertEqual('bar', h.prev())
+        self.assertEqual('foo', next(h))
+        self.assertEqual('bar', h.prev())
+        self.assertEqual('doop', h.prev())
+        self.assertEqual('woop', h.prev())
+        self.assertTrue(len(h.prev()) > 0)
+        self.assertTrue(len(h.prev()) > 0)
+        self.assertEqual('woop', next(h))
+
+    def test_step_prompt(self):
+        h = History[self.uzbl]
+        h.change_prompt('git')
+        self.assertEqual('', next(h))
+        self.assertEqual('', next(h))
+        self.assertEqual('egg', h.prev())
+        self.assertEqual('spam', h.prev())
+        self.assertTrue(len(h.prev()) > 0)
+        self.assertTrue(len(h.prev()) > 0)
+        self.assertEqual('spam', next(h))
+
+    def test_change_prompt(self):
+        h = History[self.uzbl]
+        self.assertEqual('foo', h.prev())
+        self.assertEqual('bar', h.prev())
+        h.change_prompt('git')
+        self.assertEqual('egg', h.prev())
+        self.assertEqual('spam', h.prev())
+
+    def test_exec(self):
+        modstate = set()
+        keylet = Keylet()
+        keylet.set_keycmd('foo')
+        History[self.uzbl].keycmd_exec(modstate, keylet)
+        s = SharedHistory[self.uzbl]
+        self.assertEqual(s.getline('', -1), 'foo')
+
+    def test_exec_from_history(self):
+        h = History[self.uzbl]
+        self.assertEqual('foo', h.prev())
+        self.assertEqual('bar', h.prev())
+        self.assertEqual('doop', h.prev())
+        modstate = set()
+        keylet = Keylet()
+        keylet.set_keycmd('doop')
+        h.keycmd_exec(modstate, keylet)
+        self.assertEqual('doop', h.prev())
+        self.assertEqual('foo', h.prev())
+        self.assertEqual('bar', h.prev())
+        # do we really want this one here ?
+        self.assertEqual('doop', h.prev())
+        self.assertEqual('woop', h.prev())
+
+    def test_search(self):
+        h = History[self.uzbl]
+        h.search('oop')
+        self.assertEqual('doop', h.prev())
+        self.assertEqual('woop', h.prev())
+        self.assertTrue(len(h.prev()) > 0)
+        self.assertEqual('woop', next(h))
+        self.assertEqual('doop', next(h))
+        # this reset the search
+        self.assertEqual('', next(h))
+        self.assertEqual('foo', h.prev())
+
+    def test_temp(self):
+        kl = KeyCmd[self.uzbl].keylet
+        kl.set_keycmd('uzbl')
+        h = History[self.uzbl]
+        h.change_prompt('foo')
+        # Why is the preserve current logic in this method?
+        h.history_prev(None)
+        self.assertTrue(len(h.prev()) > 0)
+        self.assertEqual('foo', next(h))
+        self.assertEqual('uzbl', next(h))
+        self.assertEqual('', next(h))  # this clears the keycmd

--- a/tests/event-manager/testhistory.py
+++ b/tests/event-manager/testhistory.py
@@ -2,13 +2,13 @@
 # vi: set et ts=4:
 
 
-
 import sys
 if '' not in sys.path:
     sys.path.insert(0, '')
 
 import unittest
 from emtest import EventManagerMock
+from six import next
 
 from uzbl.plugins.history import History, SharedHistory
 from uzbl.plugins.keycmd import Keylet, KeyCmd

--- a/tests/event-manager/testkeycmd.py
+++ b/tests/event-manager/testkeycmd.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python
+
+import re
+import mock
+import unittest
+from emtest import EventManagerMock
+from uzbl.plugins.keycmd import KeyCmd
+from uzbl.plugins.config import Config
+
+
+def getkeycmd(s):
+    return re.match(r'@\[([^\]]*)\]@', s).group(1)
+
+class KeyCmdTest(unittest.TestCase):
+    def setUp(self):
+        self.event_manager = EventManagerMock(
+            (), (KeyCmd,),
+            (), ((Config, dict),)
+        )
+        self.uzbl = self.event_manager.add()
+
+    def test_press_key(self):
+        c, k = Config[self.uzbl], KeyCmd[self.uzbl]
+        k.key_press(('', 'a'))
+        self.assertEqual(c.get('modcmd', ''), '')
+        keycmd = getkeycmd(c['keycmd'])
+        self.assertEqual(keycmd, 'a')
+
+    def test_press_keys(self):
+        c, k = Config[self.uzbl], KeyCmd[self.uzbl]
+        string = 'uzbl'
+        for char in string:
+            k.key_press(('', char))
+        self.assertEqual(c.get('modcmd', ''), '')
+        keycmd = getkeycmd(c['keycmd'])
+        self.assertEqual(keycmd, string)
+
+    def test_press_unicode_keys(self):
+        c, k = Config[self.uzbl], KeyCmd[self.uzbl]
+        string = '\u5927\u962a\u5e02'
+        for char in string:
+            k.key_press(('', char))
+        self.assertEqual(c.get('modcmd', ''), '')
+        keycmd = getkeycmd(c['keycmd'])
+        self.assertEqual(keycmd, string)

--- a/tests/event-manager/testkeycmd.py
+++ b/tests/event-manager/testkeycmd.py
@@ -11,6 +11,7 @@ from uzbl.plugins.config import Config
 def getkeycmd(s):
     return re.match(r'@\[([^\]]*)\]@', s).group(1)
 
+
 class KeyCmdTest(unittest.TestCase):
     def setUp(self):
         self.event_manager = EventManagerMock(
@@ -37,7 +38,7 @@ class KeyCmdTest(unittest.TestCase):
 
     def test_press_unicode_keys(self):
         c, k = Config[self.uzbl], KeyCmd[self.uzbl]
-        string = '\u5927\u962a\u5e02'
+        string = u'\u5927\u962a\u5e02'
         for char in string:
             k.key_press(('', char))
         self.assertEqual(c.get('modcmd', ''), '')

--- a/tests/event-manager/testmode.py
+++ b/tests/event-manager/testmode.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python
+# vi: set et ts=4:
+
+
+
+import unittest
+from emtest import EventManagerMock
+from uzbl.plugins.config import Config
+from uzbl.plugins.mode import ModePlugin
+from uzbl.plugins.on_set import OnSetPlugin
+
+class ModeParseTest(unittest.TestCase):
+    def setUp(self):
+        self.event_manager = EventManagerMock(
+            (), (OnSetPlugin, ModePlugin),
+            (), ((Config, dict),)
+        )
+        self.uzbl = self.event_manager.add()
+
+    def test_parse_config(self):
+        uzbl = self.uzbl
+        m = ModePlugin[uzbl]
+
+        mode, key, value = 'foo', 'x', 'y'
+        m.parse_mode_config((mode, key, '=', value))
+        self.assertIn(mode, m.mode_config)
+        self.assertIn(key, m.mode_config[mode])
+        self.assertEqual(m.mode_config[mode][key], value)
+
+
+class ModeTest(unittest.TestCase):
+    def setUp(self):
+        self.event_manager = EventManagerMock(
+            (), (OnSetPlugin, ModePlugin),
+            (), ((Config, dict),)
+        )
+        self.uzbl = self.event_manager.add()
+
+        mode = ModePlugin[self.uzbl]
+        config = Config[self.uzbl]
+
+        mode.parse_mode_config(('mode0', 'foo', '=', 'default'))
+
+        mode.parse_mode_config(('mode1', 'foo', '=', 'xxx'))
+        mode.parse_mode_config('mode1 bar = "spam spam"')
+        mode.parse_mode_config('mode1 baz = foo="baz"')
+
+        mode.parse_mode_config(('mode2', 'foo', '=', 'XXX'))
+        mode.parse_mode_config(('mode2', 'spam', '=', 'spam'))
+
+        config['default_mode'] = 'mode0'
+        mode.default_mode_updated(None, 'mode0')
+
+    def test_mode_sets_vars(self):
+        mode, config = ModePlugin[self.uzbl], Config[self.uzbl]
+        mode.mode_updated(None, 'mode1')
+
+        self.assertIn('foo', config)
+        self.assertIn('bar', config)
+        self.assertIn('baz', config)
+        self.assertEqual(config['foo'], 'xxx')
+        self.assertEqual(config['bar'], 'spam spam')
+        self.assertEqual(config['baz'], 'foo="baz"')
+
+    def test_mode_overwrite_vars(self):
+        mode, config = ModePlugin[self.uzbl], Config[self.uzbl]
+        config['mode'] = 'mode1'
+        mode.mode_updated(None, 'mode1')
+        config['mode'] = 'mode2'
+        mode.mode_updated(None, 'mode2')
+
+        self.assertIn('foo', config)
+        self.assertIn('bar', config)
+        self.assertIn('baz', config)
+        self.assertIn('spam', config)
+        self.assertEqual(config['foo'], 'XXX')
+        self.assertEqual(config['bar'], 'spam spam')
+        self.assertEqual(config['baz'], 'foo="baz"')
+        self.assertEqual(config['spam'], 'spam')
+
+    def test_default_mode(self):
+        ''' Setting to mode to nothing should enter the default mode'''
+        mode, config = ModePlugin[self.uzbl], Config[self.uzbl]
+
+        config['foo'] = 'nthth'
+        config['mode'] = ''
+        mode.mode_updated(None, '')
+        self.assertEqual(config['mode'], 'mode0')
+        mode.mode_updated(None, config['mode'])
+        self.assertEqual(config['mode'], 'mode0')
+        self.assertEqual(config['foo'], 'default')

--- a/tests/event-manager/testonevent.py
+++ b/tests/event-manager/testonevent.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python
+# vi: set et ts=4:
+
+
+
+import unittest
+from emtest import EventManagerMock
+from uzbl.plugins.config import Config
+from uzbl.plugins.mode import ModePlugin
+from uzbl.plugins.on_event import OnEventPlugin
+
+
+class OnEventTest(unittest.TestCase):
+    def setUp(self):
+        self.event_manager = EventManagerMock(
+            (), (OnEventPlugin,),
+        )
+        self.uzbl = self.event_manager.add()
+
+    def test_command(self):
+        oe = OnEventPlugin[self.uzbl]
+        event, command = 'FOO', 'test test'
+
+        oe.on_event(event, [], command)
+        oe.event_handler('', on_event=event)
+        self.uzbl.send.assert_called_once_with(command)
+
+    def test_matching_pattern(self):
+        oe = OnEventPlugin[self.uzbl]
+        event, pattern, command = 'FOO', ['BAR'], 'test test'
+
+        oe.on_event(event, pattern, command)
+        oe.event_handler('BAR else', on_event=event)
+        self.uzbl.send.assert_called_once_with(command)
+
+    def test_non_matching_pattern(self):
+        oe = OnEventPlugin[self.uzbl]
+        event, pattern, command = 'FOO', ['BAR'], 'test test'
+
+        oe.on_event(event, pattern, command)
+        oe.event_handler('FOO else', on_event=event)
+        self.assertFalse(self.uzbl.send.called)
+
+    def test_parse(self):
+        oe = OnEventPlugin[self.uzbl]
+        event, command = 'FOO', 'test test'
+
+        oe.parse_on_event((event, command))
+        self.assertIn(event, oe.events)
+
+    def test_parse_pattern(self):
+        oe = OnEventPlugin[self.uzbl]
+        event, pattern, command = 'FOO', 'BAR', 'test test'
+
+        oe.parse_on_event((event, '[', pattern, ']', command))
+        self.assertIn(event, oe.events)
+        commands = oe.events[event]
+        self.assertIn(command, commands)
+        self.assertEqual(commands[command], [pattern])

--- a/tests/event-manager/testonevent.py
+++ b/tests/event-manager/testonevent.py
@@ -1,8 +1,6 @@
 #!/usr/bin/env python
 # vi: set et ts=4:
 
-
-
 import unittest
 from emtest import EventManagerMock
 from uzbl.plugins.config import Config
@@ -55,5 +53,4 @@ class OnEventTest(unittest.TestCase):
         oe.parse_on_event((event, '[', pattern, ']', command))
         self.assertIn(event, oe.events)
         commands = oe.events[event]
-        self.assertIn(command, commands)
-        self.assertEqual(commands[command], [pattern])
+        self.assertIn((command, [pattern]), commands)

--- a/tests/event-manager/testprogressbar.py
+++ b/tests/event-manager/testprogressbar.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python
+# vi: set et ts=4:
+
+
+
+import sys
+if '' not in sys.path:
+    sys.path.insert(0, '')
+
+import unittest
+from emtest import EventManagerMock
+from uzbl.plugins.config import Config
+from uzbl.plugins.progress_bar import ProgressBar
+
+
+class ProgressBarTest(unittest.TestCase):
+    def setUp(self):
+        self.event_manager = EventManagerMock(
+            (), (ProgressBar,),
+            (), ((Config, dict),)
+        )
+        self.uzbl = self.event_manager.add()
+
+    def test_percent_done(self):
+        uzbl = self.uzbl
+        p, c = ProgressBar[uzbl], Config[uzbl]
+        c['progress.format'] = '%c'
+
+        p.update_progress()
+        inout = (
+            (9,   '9%'),
+            (99,  '99%'),
+            (100, '100%'),
+            #(101, '100%') # TODO
+        )
+
+        for i, o in inout:
+            p.update_progress(i)
+            self.assertEqual(c['progress.output'], o)
+
+    def test_done_char(self):
+        uzbl = self.uzbl
+        p, c = ProgressBar[uzbl], Config[uzbl]
+        c['progress.format'] = '%d'
+
+        p.update_progress()
+        inout = (
+            (9,   '='),
+            (50,  '===='),
+            (99,  '========'),
+            (100, '========'),
+            (101, '========')
+        )
+
+        for i, o in inout:
+            p.update_progress(i)
+            self.assertEqual(c['progress.output'], o)
+
+    def test_pending_char(self):
+        uzbl = self.uzbl
+        p, c = ProgressBar[uzbl], Config[uzbl]
+        c['progress.format'] = '%p'
+        c['progress.pending'] = '-'
+
+        p.update_progress()
+        inout = (
+            (9,   '-------'),
+            (50,  '----'),
+            (99,  ''),
+            (100, ''),
+            (101, '')
+        )
+
+        for i, o in inout:
+            p.update_progress(i)
+            self.assertEqual(c['progress.output'], o)
+
+    def test_percent_pending(self):
+        uzbl = self.uzbl
+        p, c = ProgressBar[uzbl], Config[uzbl]
+        c['progress.format'] = '%t'
+
+        p.update_progress()
+        inout = (
+            (9,   '91%'),
+            (50,  '50%'),
+            (99,  '1%'),
+            (100, '0%'),
+            #(101, '0%')  # TODO
+        )
+
+        for i, o in inout:
+            p.update_progress(i)
+            self.assertEqual(c['progress.output'], o)

--- a/uzbl/plugins/completion.py
+++ b/uzbl/plugins/completion.py
@@ -169,7 +169,7 @@ class CompletionPlugin(PerInstancePlugin):
         self.update_completion_list()
 
     def add_builtins(self, builtins):
-        '''Pump the space delimited list of builtin commands into the
+        '''Pump the json encoded list of builtin commands into the
         builtin list.'''
 
         builtins = json.loads(builtins)

--- a/uzbl/plugins/downloads.py
+++ b/uzbl/plugins/downloads.py
@@ -2,7 +2,10 @@
 # @downloads to your status_format.
 
 import os
-import html
+try:
+    from html import escape
+except ImportError:
+    from cgi import escape
 
 from uzbl.arguments import splitquoted
 from .config import Config
@@ -34,7 +37,7 @@ class Downloads(PerInstancePlugin):
                 # replace entities to make sure we don't break our markup
                 # (this could be done with an @[]@ expansion in uzbl, but then we
                 # can't use the &#10; above to make a new line)
-                dl = html.escape(dl)
+                dl = escape(dl)
                 result += dl
         else:
             result = ''

--- a/uzbl/plugins/history.py
+++ b/uzbl/plugins/history.py
@@ -91,6 +91,9 @@ class History(PerInstancePlugin):
             return ''
         return shared.getline(self.prompt, self.cursor)
 
+    # Python2 shenanigans
+    next = __next__
+
     def change_prompt(self, prompt):
         self.prompt = prompt
         self._tail = None

--- a/uzbl/plugins/keycmd.py
+++ b/uzbl/plugins/keycmd.py
@@ -1,4 +1,5 @@
 import re
+import six
 
 from uzbl.arguments import splitquoted
 from uzbl.ext import PerInstancePlugin
@@ -382,7 +383,7 @@ class KeyCmd(PerInstancePlugin):
 
         elif new_keycmd == keycmd:
             # Generate the pango markup for the cursor in the keycmd.
-            config['keycmd'] = str(k.markup())
+            config['keycmd'] = six.text_type(k.markup())
 
     def parse_key_event(self, key):
         ''' Build a set from the modstate part of the event, and pass all keys through modmap '''


### PR DESCRIPTION
I performed some necromancy on the old event-manager tests and patched them back up to snuff. If you enable travis (and coveralls) on uzbl/uzbl we could also have automatic testing of any pull-request coming in through github.