### PR TITLE
Web extensions dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ PREFIX     ?= /usr/local
 INSTALLDIR ?= $(DESTDIR)$(PREFIX)
 MANDIR     ?= $(INSTALLDIR)/share/man
 DOCDIR     ?= $(INSTALLDIR)/share/uzbl/docs
+LIBDIR     ?= $(INSTALLDIR)/lib/uzbl
 RUN_PREFIX ?= $(PREFIX)
 INSTALL    ?= install -p
 
@@ -67,7 +68,7 @@ ARCH := $(shell uname -m)
 
 COMMIT_HASH := $(shell ./misc/hash.sh)
 
-CPPFLAGS += -D_XOPEN_SOURCE=500 -DARCH=\"$(ARCH)\" -DCOMMIT=\"$(COMMIT_HASH)\"
+CPPFLAGS += -D_XOPEN_SOURCE=500 -DARCH=\"$(ARCH)\" -DCOMMIT=\"$(COMMIT_HASH)\" -DLIBDIR=\"$(LIBDIR)\"
 
 HAVE_LIBSOUP_VERSION := $(shell pkg-config --exists 'libsoup-2.4 >= 2.41.1' && echo yes)
 ifeq ($(HAVE_LIBSOUP_VERSION),yes)

--- a/src/commands.c
+++ b/src/commands.c
@@ -652,7 +652,7 @@ DECLARE_COMMAND (cache);
 DECLARE_COMMAND (favicon);
 DECLARE_COMMAND (css);
 #ifdef USE_WEBKIT2
-#if WEBKIT_CHECK_VERSION (2, 5, 1)
+#if WEBKIT_CHECK_VERSION (2, 8, 0)
 DECLARE_COMMAND (script);
 #endif
 #endif
@@ -749,7 +749,7 @@ builtin_command_table[] = {
     { "favicon",                        cmd_favicon,                  TRUE,  TRUE  },
     { "css",                            cmd_css,                      TRUE,  TRUE  },
 #ifdef USE_WEBKIT2
-#if WEBKIT_CHECK_VERSION (2, 5, 1)
+#if WEBKIT_CHECK_VERSION (2, 8, 0)
     { "script",                         cmd_script,                   TRUE,  TRUE  },
 #endif
 #endif
@@ -1831,7 +1831,7 @@ IMPLEMENT_COMMAND (css)
 }
 
 #ifdef USE_WEBKIT2
-#if WEBKIT_CHECK_VERSION (2, 5, 1)
+#if WEBKIT_CHECK_VERSION (2, 8, 0)
 static void
 script_message_callback (WebKitUserContentManager *manager, WebKitJavascriptResult *res, gpointer data);
 

--- a/src/gui.c
+++ b/src/gui.c
@@ -1678,10 +1678,16 @@ send_hover_event (const gchar *uri, const gchar *title)
 void
 set_window_property (const gchar *prop, const gchar *value)
 {
-    if (uzbl.gui.main_window && GTK_IS_WIDGET (uzbl.gui.main_window))
-    {
+    GdkWindow *window;
+
+    if (uzbl.gui.main_window && GTK_IS_WIDGET (uzbl.gui.main_window)) {
+        if (!(window = gtk_widget_get_window (uzbl.gui.main_window))) {
+            uzbl_debug ("Could not get gdk handle of window");
+            return;
+        }
+
         gdk_property_change (
-            gtk_widget_get_window (uzbl.gui.main_window),
+            window,
             gdk_atom_intern_static_string (prop),
             gdk_atom_intern_static_string ("STRING"),
             CHAR_BIT * sizeof (value[0]),

--- a/src/uzbl-core.c
+++ b/src/uzbl-core.c
@@ -72,31 +72,34 @@ uzbl_init (int *argc, char ***argv)
     gchar *geometry = NULL;
     gboolean print_version = FALSE;
     gboolean bug_info = FALSE;
+    gchar *web_extensions_dir = LIBDIR "/web-extensions";
 
     /* Commandline arguments. */
     const GOptionEntry
     options[] = {
-        { "uri",            'u', 0, G_OPTION_ARG_STRING,       &uri,
+        { "uri",               'u', 0, G_OPTION_ARG_STRING,       &uri,
             "Uri to load at startup (equivalent to 'uzbl <uri>' after uzbl has launched)", "URI" },
-        { "verbose",        'v', 0, G_OPTION_ARG_NONE,         &verbose,
-            "Whether to print all messages or just errors.",                                                  NULL },
-        { "named",          'n', 0, G_OPTION_ARG_STRING,       &uzbl.state.instance_name,
-            "Name of the current instance (defaults to Xorg window id or random for GtkSocket mode)",         "NAME" },
-        { "config",         'c', 0, G_OPTION_ARG_STRING,       &config_file,
-            "Path to config file or '-' for stdin",                                                           "FILE" },
+        { "verbose",           'v', 0, G_OPTION_ARG_NONE,         &verbose,
+            "Whether to print all messages or just errors.",                                                 NULL },
+        { "named",             'n', 0, G_OPTION_ARG_STRING,       &uzbl.state.instance_name,
+            "Name of the current instance (defaults to Xorg window id or random for GtkSocket mode)",        "NAME" },
+        { "config",            'c', 0, G_OPTION_ARG_STRING,       &config_file,
+            "Path to config file or '-' for stdin",                                                          "FILE" },
         /* TODO: explain the difference between these two options */
-        { "xembed-socket",  's', 0, G_OPTION_ARG_INT,          &uzbl.state.xembed_socket_id,
-            "Xembed socket ID, this window should embed itself",                                              "SOCKET" },
-        { "connect-socket",  0,  0, G_OPTION_ARG_STRING_ARRAY, &connect_socket_names,
-            "Connect to server socket for event managing",                                                    "CSOCKET" },
-        { "print-events",   'p', 0, G_OPTION_ARG_NONE,         &print_events,
-            "Whether to print events to stdout.",                                                             NULL },
-        { "geometry",       'g', 0, G_OPTION_ARG_STRING,       &geometry,
-            "Set window geometry (format: 'WIDTHxHEIGHT+-X+-Y' or 'maximized')",                              "GEOMETRY" },
-        { "version",        'V', 0, G_OPTION_ARG_NONE,         &print_version,
-            "Print the version and exit",                                                                     NULL },
-        { "bug-info",       'B', 0, G_OPTION_ARG_NONE,         &bug_info,
-            "Print information for a bug report and exit",                                                    NULL },
+        { "xembed-socket",     's', 0, G_OPTION_ARG_INT,          &uzbl.state.xembed_socket_id,
+            "Xembed socket ID, this window should embed itself",                                             "SOCKET" },
+        { "connect-socket",     0,  0, G_OPTION_ARG_STRING_ARRAY, &connect_socket_names,
+            "Connect to server socket for event managing",                                                   "CSOCKET" },
+        { "print-events",      'p', 0, G_OPTION_ARG_NONE,         &print_events,
+            "Whether to print events to stdout.",                                                            NULL },
+        { "geometry",          'g', 0, G_OPTION_ARG_STRING,       &geometry,
+            "Set window geometry (format: 'WIDTHxHEIGHT+-X+-Y' or 'maximized')",                             "GEOMETRY" },
+        { "version",           'V', 0, G_OPTION_ARG_NONE,         &print_version,
+            "Print the version and exit",                                                                    NULL },
+        { "bug-info",          'B', 0, G_OPTION_ARG_NONE,         &bug_info,
+            "Print information for a bug report and exit",                                                   NULL },
+        { "web-extensions-dir", 0,  0, G_OPTION_ARG_STRING,       &web_extensions_dir,
+            "Directory that will be searched for webkit extensions",                                         "DIR" },
         { NULL,      0, 0, 0, NULL, NULL, NULL }
     };
 
@@ -172,9 +175,10 @@ uzbl_init (int *argc, char ***argv)
 #endif
 
 #if USE_WEBKIT2
+    WebKitWebContext *webkit_context = webkit_web_context_get_default ();
+
 #if WEBKIT_CHECK_VERSION (2, 3, 5)
     /* Use this in the hopes that one day uzbl itself can be multi-threaded. */
-    WebKitWebContext *webkit_context = webkit_web_context_get_default ();
     WebKitProcessModel model =
 #if WEBKIT_CHECK_VERSION (2, 3, 90)
         WEBKIT_PROCESS_MODEL_MULTIPLE_SECONDARY_PROCESSES
@@ -183,6 +187,8 @@ uzbl_init (int *argc, char ***argv)
 #endif
         ;
     webkit_web_context_set_process_model (webkit_context, model);
+    webkit_web_context_set_web_extensions_directory (webkit_context,
+                                                     web_extensions_dir);
 #endif
 #endif
 

--- a/src/variables.c
+++ b/src/variables.c
@@ -1369,7 +1369,6 @@ DECLARE_GETSET (gchar *, local_storage_path);
 #if WEBKIT_CHECK_VERSION (1, 11, 92)
 DECLARE_SETTER (gchar *, disk_cache_directory);
 #endif
-DECLARE_SETTER (gchar *, web_extensions_directory);
 #endif
 
 /* Hacks */
@@ -1452,7 +1451,6 @@ struct _UzblVariablesPrivate {
 #if WEBKIT_CHECK_VERSION (1, 11, 92)
     gchar *disk_cache_directory;
 #endif
-    gchar *web_extensions_directory;
 #endif
 };
 
@@ -1718,7 +1716,6 @@ uzbl_variables_private_new (GHashTable *table)
 #if WEBKIT_CHECK_VERSION (1, 11, 92)
         { "disk_cache_directory",         UZBL_V_STRING (priv->disk_cache_directory,           set_disk_cache_directory)},
 #endif
-        { "web_extensions_directory",     UZBL_V_STRING (priv->web_extensions_directory,       set_web_extensions_directory)},
 #endif
 
         /* Hacks */
@@ -3014,18 +3011,6 @@ IMPLEMENT_SETTER (gchar *, disk_cache_directory)
 
     WebKitWebContext *context = webkit_web_view_get_context (uzbl.gui.web_view);
     webkit_web_context_set_disk_cache_directory (context, uzbl.variables->priv->disk_cache_directory);
-
-    return TRUE;
-}
-#endif
-
-IMPLEMENT_SETTER (gchar *, web_extensions_directory)
-{
-    g_free (uzbl.variables->priv->web_extensions_directory);
-    uzbl.variables->priv->web_extensions_directory = g_strdup (web_extensions_directory);
-
-    WebKitWebContext *context = webkit_web_view_get_context (uzbl.gui.web_view);
-    webkit_web_context_set_web_extensions_directory (context, uzbl.variables->priv->web_extensions_directory);
 
     return TRUE;
 }

--- a/src/variables.c
+++ b/src/variables.c
@@ -1092,7 +1092,7 @@ expand_type (const gchar *str)
 #endif
 
 #ifdef USE_WEBKIT2
-#if WEBKIT_CHECK_VERSION (1, 7, 2)
+#if WEBKIT_CHECK_VERSION (2, 8, 0)
 #define HAVE_LOCAL_STORAGE_PATH
 #endif
 #else
@@ -2994,7 +2994,7 @@ IMPLEMENT_SETTER (unsigned long long, web_database_quota)
 #endif
 
 #ifdef USE_WEBKIT2
-#if WEBKIT_CHECK_VERSION (1, 7, 2)
+#if WEBKIT_CHECK_VERSION (2, 8, 0)
 GOBJECT_GETSET (gchar *, local_storage_path,
                 webkit_context (), "local-storage-directory")
 #endif


### PR DESCRIPTION
by default try to load extensions from $LIBDIR/uzbl/web-extensions but possible to override using a command line flag

there's a few assorted fixes in separate commits that I needed to get it to build on the wk2 in fedora 21