### PR TITLE
Web extensions dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ INSTALLDIR ?= $(DESTDIR)$(PREFIX)
 SHAREDIR   ?= $(INSTALLDIR)/share
 MANDIR     ?= $(SHAREDIR)/man
 DOCDIR     ?= $(SHAREDIR)/uzbl/docs
+LIBDIR     ?= $(INSTALLDIR)/lib$(LIB_SUFFIX)/uzbl
 RUN_PREFIX ?= $(PREFIX)
 INSTALL    ?= install -p
 
@@ -68,7 +69,7 @@ ARCH := $(shell uname -m)
 
 COMMIT_HASH := $(shell ./misc/hash.sh)
 
-CPPFLAGS += -D_XOPEN_SOURCE=500 -DARCH=\"$(ARCH)\" -DCOMMIT=\"$(COMMIT_HASH)\"
+CPPFLAGS += -D_XOPEN_SOURCE=500 -DARCH=\"$(ARCH)\" -DCOMMIT=\"$(COMMIT_HASH)\" -DLIBDIR=\"$(LIBDIR)\"
 
 HAVE_LIBSOUP_VERSION := $(shell pkg-config --exists 'libsoup-2.4 >= 2.41.1' && echo yes)
 ifeq ($(HAVE_LIBSOUP_VERSION),yes)

--- a/README.md
+++ b/README.md
@@ -1573,6 +1573,8 @@ where `arguments` and `uri` are both optional. `arguments` can be:
     embedded.
 * `-V`, `--version`
   - Print the version and exit.
+* `--web-extensions-dir`
+  - Directory that will be searched for webkit extensions
 * `--display=DISPLAY`
   - X display to use.
 * `--help`

--- a/src/commands.c
+++ b/src/commands.c
@@ -652,7 +652,7 @@ DECLARE_COMMAND (cache);
 DECLARE_COMMAND (favicon);
 DECLARE_COMMAND (css);
 #ifdef USE_WEBKIT2
-#if WEBKIT_CHECK_VERSION (2, 5, 1)
+#if WEBKIT_CHECK_VERSION (2, 7, 2)
 DECLARE_COMMAND (script);
 #endif
 #endif
@@ -750,7 +750,7 @@ builtin_command_table[] = {
     { "favicon",                        cmd_favicon,                  TRUE,  TRUE  },
     { "css",                            cmd_css,                      TRUE,  TRUE  },
 #ifdef USE_WEBKIT2
-#if WEBKIT_CHECK_VERSION (2, 5, 1)
+#if WEBKIT_CHECK_VERSION (2, 7, 2)
     { "script",                         cmd_script,                   TRUE,  TRUE  },
 #endif
 #endif
@@ -1838,7 +1838,7 @@ IMPLEMENT_COMMAND (css)
 }
 
 #ifdef USE_WEBKIT2
-#if WEBKIT_CHECK_VERSION (2, 5, 1)
+#if WEBKIT_CHECK_VERSION (2, 7, 2)
 static void
 script_message_callback (WebKitUserContentManager *manager, WebKitJavascriptResult *res, gpointer data);
 

--- a/src/uzbl-core.c
+++ b/src/uzbl-core.c
@@ -76,27 +76,29 @@ uzbl_init (int *argc, char ***argv)
     /* Commandline arguments. */
     const GOptionEntry
     options[] = {
-        { "uri",            'u', 0, G_OPTION_ARG_STRING,       &uri,
+        { "uri",               'u', 0, G_OPTION_ARG_STRING,       &uri,
             "Uri to load at startup (equivalent to 'uzbl <uri>' after uzbl has launched)", "URI" },
-        { "verbose",        'v', 0, G_OPTION_ARG_NONE,         &verbose,
-            "Whether to print all messages or just errors.",                                                  NULL },
-        { "named",          'n', 0, G_OPTION_ARG_STRING,       &uzbl.state.instance_name,
-            "Name of the current instance (defaults to Xorg window id or random for GtkSocket mode)",         "NAME" },
-        { "config",         'c', 0, G_OPTION_ARG_STRING,       &config_file,
-            "Path to config file or '-' for stdin",                                                           "FILE" },
+        { "verbose",           'v', 0, G_OPTION_ARG_NONE,         &verbose,
+            "Whether to print all messages or just errors.",                                                 NULL },
+        { "named",             'n', 0, G_OPTION_ARG_STRING,       &uzbl.state.instance_name,
+            "Name of the current instance (defaults to Xorg window id or random for GtkSocket mode)",        "NAME" },
+        { "config",            'c', 0, G_OPTION_ARG_STRING,       &config_file,
+            "Path to config file or '-' for stdin",                                                          "FILE" },
         /* TODO: explain the difference between these two options */
-        { "xembed-socket",  's', 0, G_OPTION_ARG_INT,          &uzbl.state.xembed_socket_id,
-            "Xembed socket ID, this window should embed itself",                                              "SOCKET" },
-        { "connect-socket",  0,  0, G_OPTION_ARG_STRING_ARRAY, &connect_socket_names,
-            "Connect to server socket for event managing",                                                    "CSOCKET" },
-        { "print-events",   'p', 0, G_OPTION_ARG_NONE,         &print_events,
-            "Whether to print events to stdout.",                                                             NULL },
-        { "geometry",       'g', 0, G_OPTION_ARG_STRING,       &geometry,
-            "Set window geometry (format: 'WIDTHxHEIGHT+-X+-Y' or 'maximized')",                              "GEOMETRY" },
-        { "version",        'V', 0, G_OPTION_ARG_NONE,         &print_version,
-            "Print the version and exit",                                                                     NULL },
-        { "bug-info",       'B', 0, G_OPTION_ARG_NONE,         &bug_info,
-            "Print information for a bug report and exit",                                                    NULL },
+        { "xembed-socket",     's', 0, G_OPTION_ARG_INT,          &uzbl.state.xembed_socket_id,
+            "Xembed socket ID, this window should embed itself",                                             "SOCKET" },
+        { "connect-socket",     0,  0, G_OPTION_ARG_STRING_ARRAY, &connect_socket_names,
+            "Connect to server socket for event managing",                                                   "CSOCKET" },
+        { "print-events",      'p', 0, G_OPTION_ARG_NONE,         &print_events,
+            "Whether to print events to stdout.",                                                            NULL },
+        { "geometry",          'g', 0, G_OPTION_ARG_STRING,       &geometry,
+            "Set window geometry (format: 'WIDTHxHEIGHT+-X+-Y' or 'maximized')",                             "GEOMETRY" },
+        { "version",           'V', 0, G_OPTION_ARG_NONE,         &print_version,
+            "Print the version and exit",                                                                    NULL },
+        { "bug-info",          'B', 0, G_OPTION_ARG_NONE,         &bug_info,
+            "Print information for a bug report and exit",                                                   NULL },
+        { "web-extensions-dir", 0,  0, G_OPTION_ARG_STRING,       &uzbl.state.web_extensions_directory,
+            "Directory that will be searched for webkit extensions",                                         "DIR" },
         { NULL,      0, 0, 0, NULL, NULL, NULL }
     };
 
@@ -106,6 +108,10 @@ uzbl_init (int *argc, char ***argv)
     g_option_context_add_group (context, gtk_get_option_group (TRUE));
     g_option_context_parse (context, argc, argv, NULL);
     g_option_context_free (context);
+
+    if (!uzbl.state.web_extensions_directory) {
+      uzbl.state.web_extensions_directory = LIBDIR "/web-extensions";
+    }
 
     /* Print bug information. */
     if (bug_info) {
@@ -172,9 +178,10 @@ uzbl_init (int *argc, char ***argv)
 #endif
 
 #if USE_WEBKIT2
+    WebKitWebContext *webkit_context = webkit_web_context_get_default ();
+
 #if WEBKIT_CHECK_VERSION (2, 3, 5)
     /* Use this in the hopes that one day uzbl itself can be multi-threaded. */
-    WebKitWebContext *webkit_context = webkit_web_context_get_default ();
     WebKitProcessModel model =
 #if WEBKIT_CHECK_VERSION (2, 3, 90)
         WEBKIT_PROCESS_MODEL_MULTIPLE_SECONDARY_PROCESSES
@@ -188,6 +195,8 @@ uzbl_init (int *argc, char ***argv)
     /* TODO: expose command line option for this. */
     webkit_web_context_set_web_process_count_limit (webkit_context, 0);
 #endif
+    webkit_web_context_set_web_extensions_directory (webkit_context,
+                                                     uzbl.state.web_extensions_directory);
 #endif
 #endif
 

--- a/src/uzbl-core.h
+++ b/src/uzbl-core.h
@@ -50,6 +50,10 @@ typedef struct {
 
     /* Events */
     int             xembed_socket_id;
+
+#ifdef USE_WEBKIT2
+    gchar *web_extensions_directory;
+#endif
 } UzblState;
 
 /* Networking */

--- a/src/variables.c
+++ b/src/variables.c
@@ -419,7 +419,7 @@ uzbl_variables_dump_events ()
 void
 variable_free (UzblVariable *variable)
 {
-    if ((variable->type == TYPE_STR) && variable->value.s) {
+    if ((variable->type == TYPE_STR) && variable->value.s && variable->writeable) {
         g_free (*variable->value.s);
         if (!variable->builtin) {
             g_free (variable->value.s);
@@ -1385,7 +1385,6 @@ DECLARE_GETSET (gchar *, local_storage_path);
 #if WEBKIT_CHECK_VERSION (1, 11, 92)
 DECLARE_SETTER (gchar *, disk_cache_directory);
 #endif
-DECLARE_SETTER (gchar *, web_extensions_directory);
 #if WEBKIT_CHECK_VERSION (2, 9, 2)
 DECLARE_GETSET (gchar *, indexed_db_directory);
 #endif
@@ -1488,7 +1487,6 @@ struct _UzblVariablesPrivate {
 #elif WEBKIT_CHECK_VERSION (1, 11, 92)
     gchar *disk_cache_directory;
 #endif
-    gchar *web_extensions_directory;
 #endif
 };
 
@@ -1768,7 +1766,7 @@ uzbl_variables_private_new (GHashTable *table)
 #endif
                                           },
 #endif
-        { "web_extensions_directory",     UZBL_V_STRING (priv->web_extensions_directory,       set_web_extensions_directory)},
+        { "web_extensions_directory",     UZBL_C_STRING (uzbl.state.web_extensions_directory)},
 #if WEBKIT_CHECK_VERSION (2, 9, 2)
         { "indexed_db_directory",         UZBL_V_FUNC (indexed_db_directory,                   STR)},
 #endif
@@ -3154,17 +3152,6 @@ IMPLEMENT_SETTER (gchar *, disk_cache_directory)
     return TRUE;
 }
 #endif
-
-IMPLEMENT_SETTER (gchar *, web_extensions_directory)
-{
-    g_free (uzbl.variables->priv->web_extensions_directory);
-    uzbl.variables->priv->web_extensions_directory = g_strdup (web_extensions_directory);
-
-    WebKitWebContext *context = webkit_web_view_get_context (uzbl.gui.web_view);
-    webkit_web_context_set_web_extensions_directory (context, uzbl.variables->priv->web_extensions_directory);
-
-    return TRUE;
-}
 
 #if WEBKIT_CHECK_VERSION (2, 9, 4)
 GOBJECT_GETSET (gchar *, indexed_db_directory,


### PR DESCRIPTION
by default try to load extensions from $LIBDIR/uzbl/web-extensions but possible to override using a command line flag

there's a few assorted fixes in separate commits that I needed to get it to build on the wk2 in fedora 21

reopen because of silly misconfigured upstream