### PR TITLE
Update load_url_from_bookmarks.sh

### DIFF
--- a/examples/data/scripts/load_url_from_bookmarks.sh
+++ b/examples/data/scripts/load_url_from_bookmarks.sh
@@ -13,7 +13,7 @@ readonly DMENU_OPTIONS="xmms vertical resize"
 
 if $DMENU_HAS_VERTICAL; then
     # show tags as well
-    goto="$( $DMENU < "$UZBL_BOOKMARKS_FILE" | cut -d "	" -f 1 )"
+    goto="$( $DMENU < "$UZBL_BOOKMARKS_FILE" | cut -d " " -f 1 )"
 else
     # because they are all after each other, just show the url, not their tags.
     goto="$( cut -d "	" -f 1 < "$UZBL_BOOKMARKS_FILE" | $DMENU )"


### PR DESCRIPTION
In the default config https://github.com/uzbl/uzbl/blob/next/examples/config/config\#L364 the bookmarks are added with the tag and uri separated by a whitespace. However, in this script, a bookmark is cut on the tab '\t' character.