### PR TITLE
docs: fix replacement for toggle_zoom_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -689,7 +689,7 @@ variables are treated as strings.
 * `zoom_step` (double) (default: 0.1)
   - The amount to step by default with the `zoom in` and `zoom out` commands.
     Must be greater than 0.
-* `zoom_text_only` (boolean) (default: 1)
+* `zoom_text_only` (boolean) (default: 0)
   - If non-zero, only text will be zoomed on a page.
 * `caret_browsing` (boolean) (default: 0)
   - If non-zero, pages may be navigated using the arrows to move a cursor

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -171,7 +171,7 @@ major exception here).
 * `toggle_zoom_type`
   - *Change*: Removed.
   - *Rationale*: Unnecessary command.
-  - *Porting*: Use `toggle zoom_type`.
+  - *Porting*: Use `toggle zoom_text_only`.
 * `zoom_in`
   - *Change*: Removed
   - *Rationale*: Consolidated into the new `zoom` command.

--- a/src/config.h
+++ b/src/config.h
@@ -14,6 +14,7 @@ default_config[] = {
 "set shell_cmd /bin/sh -c",
 "set maintain_history 1", /* Set here since the WebKit default is 1, but there's no way to get the current value. */
 "set forward_keys 1", /* Forward keys by default so that webpages work as expected without a config. */
+"set zoom_text_only 0", /* Zoom all content by default; text-only is not as useful. */
 NULL
 };
 


### PR DESCRIPTION
---
@keis Also considering just changing the default for `zoom_text_only` to 0. Now that I have a high-DPI device, `1` is not what people want by default.