### PR TITLE
sandbox: unset UZBL_EVENT_SOCKET

### DIFF
--- a/misc/env.sh
+++ b/misc/env.sh
@@ -29,6 +29,8 @@ export XDG_CONFIG_HOME
 PATH="$( pwd )/sandbox/usr/bin:$PATH"
 export PATH
 
+unset UZBL_EVENT_SOCKET
+
 . sandbox/bin/activate
 
 exec "$@"


### PR DESCRIPTION
The sandbox shouldn't use any custom socket path.