### PR TITLE
Fix daemonization of event manager

### DIFF
--- a/uzbl/event_manager.py
+++ b/uzbl/event_manager.py
@@ -206,7 +206,7 @@ class UzblEventDaemon(object):
             daemonize()
 
             # Update the pid file
-            make_pid_file(opts.pid_file)
+            make_pid_file(self.opts.pid_file)
 
         asyncore.loop()
 


### PR DESCRIPTION
In the code that starts the event manager in daemon mode, an
improper reference to 'opts.pid_file' results in the event
manager shutting down as soon as it is daemonized.

The correct reference should be 'self.opts.pid_file', following
the changes that made the 'opts' object non-global.

---
@keis 