### PR TITLE
used new syntax to reference style.css from example config

### DIFF
--- a/examples/config/config
+++ b/examples/config/config
@@ -298,8 +298,8 @@ set history_disable_easter_egg 1
 @cbind  ?*                           = search rfind %s
 @cbind  <Ctrl>?<'reverse search':>_  = search rfind %s
 # Jump to next and previous items
-@cbind  n   = search find
-@cbind  N   = search rfind
+@cbind  n   = search next
+@cbind  N   = search prev
 
 # Print pages to a printer
 @cbind  <Ctrl>p = hardcopy page

--- a/examples/config/config
+++ b/examples/config/config
@@ -101,7 +101,7 @@ set download_handler       spawn_sync @scripts_dir/download.sh
 # === Behaviour and appearance ===============================================
 
 # Custom CSS can be defined here, including link follower hint styles
-set stylesheet_uri file://@config_home/style.css
+css add file://@config_home/style.css
 
 # If WebKits builtin authentication dialog should be used, if enabling remember
 # to disable external authentication handlers

--- a/examples/data/scripts/per-site-settings.py
+++ b/examples/data/scripts/per-site-settings.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 # Per-site settings plugin
 
 # Example configuration usage:


### PR DESCRIPTION
Simple change to avoid confusion;

I think there was somebody on the mailing list some months ago who had been unable to figure out how to have style.css actually apply.