### PR TITLE
introduced 'proxy_section' to status bar (refs issue #194)

### DIFF
--- a/examples/config/config
+++ b/examples/config/config
@@ -130,9 +130,11 @@ set status_section    <span foreground="orange">\@status_message</span>
 set selected_section  <span foreground="#606060">\@[\@SELECTED_URI]\@</span>
 
 set download_section  <span foreground="white">\@downloads</span>
+set proxy_section     <span foreground="cyan">\@[\@proxy_url]\@</span>
 
 set status_format       <span font_family="monospace">@mode_section @keycmd_section @progress_section @name_section @status_section @scroll_section @selected_section @download_section</span>
 set status_format_right <span font_family="monospace"><span foreground="#666">uri:</span> @uri_section</span>
+set status_format_right <span font_family="monospace"><span foreground="#666">proxy:</span> @proxy_section <span foreground="#666">uri:</span> @uri_section</span>
 
 set title_format_long \@keycmd_prompt \@raw_modcmd \@raw_keycmd \@TITLE - Uzbl browser <\@NAME> \@SELECTED_URI
 
@@ -166,7 +168,9 @@ set cookie_policy always
 # === Proxy configuration  ===================================================
 
 # Direct uzbl at a proxy service (ex. privoxy)
-# set proxy_url http://localhost:8118
+# The trailing '#privoxy' part is for displaying purposes only (see proxy_section).
+# Apparently it is ignored as far as actual operation is concerned.
+# set proxy_url http://localhost:8118#privoxy
 
 # === Key binding configuration ==============================================
 # --- Internal modmapping and ignoring ---------------------------------------


### PR DESCRIPTION
Note that displaying the @proxy_url with this stopped working some months back.
Now only '/' is shown even though the correct proxy is actually used (localhost..).

Any ideas as to why?