### PR TITLE
added/improved basic VIM-style key bindings

### DIFF
--- a/examples/config/config
+++ b/examples/config/config
@@ -259,13 +259,9 @@ set history_disable_easter_egg 1
 
 # Page movement binds
 @cbind  j              = scroll vertical 100
-@cbind  J              = scroll vertical 50
 @cbind  k              = scroll vertical -100
-@cbind  K              = scroll vertical -50
 @cbind  h              = scroll horizontal -100
-@cbind  H              = scroll horizontal -50
 @cbind  l              = scroll horizontal 100
-@cbind  L              = scroll horizontal 50
 @cbind  <Page_Up>      = scroll vertical -100%
 @cbind  <Page_Down>    = scroll vertical 100%
 @cbind  <Ctrl>f        = scroll vertical 100%
@@ -320,7 +316,7 @@ set history_disable_easter_egg 1
 
 # Web searching binds
 # NOTE you may search Google by adding "!g" to your DuckDuckGo search string
-@cbind  d<DuckDuckGo:>_      = uri http://duckduckgo.com/?q=%s
+@cbind  ddg<DuckDuckGo:>_      = uri http://duckduckgo.com/?q=\@-encodeURIComponent(%r)-\@
 # These bindings should be entered as simply \wiki but due to escaping
 # happening in multiple stages it needs to be written like this
 @cbind  \\\\awiki<Archwiki:>_  = uri http://wiki.archlinux.org/index.php/Special:Search?search=\@-encodeURIComponent(%r)-\@&go=Go
@@ -330,7 +326,6 @@ set history_disable_easter_egg 1
 # Set function shortcut
 @cbind  s<var:>_<value:>_  = set %1 %2
 # Exit binding
-@cbind  q                  = exit
 @cbind  ZZ                 = exit
 # Dump config to stdout
 @cbind  !dump              = spawn_sh 'echo dump_config > "$UZBL_FIFO"'

--- a/examples/config/config
+++ b/examples/config/config
@@ -187,6 +187,8 @@ set cookie_policy always
 @ignore_key <Shift>
 @ignore_key <Multi_key>
 @ignore_key <Mod2>
+@ignore_key <Mod4>
+@ignore_key <Mod5>
 
 # --- Bind aliases -----------------------------------------------------------
 
@@ -256,14 +258,20 @@ set history_disable_easter_egg 1
 @cbind  w            = event REQ_NEW_WINDOW
 
 # Page movement binds
-@cbind  j              = scroll vertical 20
-@cbind  k              = scroll vertical -20
-@cbind  h              = scroll horizontal -20
-@cbind  l              = scroll horizontal 20
+@cbind  j              = scroll vertical 100
+@cbind  J              = scroll vertical 50
+@cbind  k              = scroll vertical -100
+@cbind  K              = scroll vertical -50
+@cbind  h              = scroll horizontal -100
+@cbind  H              = scroll horizontal -50
+@cbind  l              = scroll horizontal 100
+@cbind  L              = scroll horizontal 50
 @cbind  <Page_Up>      = scroll vertical -100%
 @cbind  <Page_Down>    = scroll vertical 100%
 @cbind  <Ctrl>f        = scroll vertical 100%
 @cbind  <Ctrl>b        = scroll vertical -100%
+@cbind  gg             = scroll vertical begin
+@cbind  G              = scroll vertical end
 @cbind  <<             = scroll vertical begin
 @cbind  >>             = scroll vertical end
 @cbind  <Home>         = scroll vertical begin
@@ -311,8 +319,8 @@ set history_disable_easter_egg 1
 @cbind  <Ctrl>p = hardcopy page
 
 # Web searching binds
-@cbind  gg<Google:>_         = uri http://www.google.com/search?q=\@-encodeURIComponent(%r)-\@
-@cbind  ddg<DuckDuckGo:>_    = uri http://duckduckgo.com/?q=\@-encodeURIComponent(%r)-\@
+# NOTE you may search Google by adding "!g" to your DuckDuckGo search string
+@cbind  d<DuckDuckGo:>_      = uri http://duckduckgo.com/?q=%s
 # These bindings should be entered as simply \wiki but due to escaping
 # happening in multiple stages it needs to be written like this
 @cbind  \\\\awiki<Archwiki:>_  = uri http://wiki.archlinux.org/index.php/Special:Search?search=\@-encodeURIComponent(%r)-\@&go=Go
@@ -322,6 +330,7 @@ set history_disable_easter_egg 1
 # Set function shortcut
 @cbind  s<var:>_<value:>_  = set %1 %2
 # Exit binding
+@cbind  q                  = exit
 @cbind  ZZ                 = exit
 # Dump config to stdout
 @cbind  !dump              = spawn_sh 'echo dump_config > "$UZBL_FIFO"'

--- a/examples/config/config
+++ b/examples/config/config
@@ -316,7 +316,7 @@ set history_disable_easter_egg 1
 
 # Web searching binds
 # NOTE you may search Google by adding "!g" to your DuckDuckGo search string
-@cbind  ddg<DuckDuckGo:>_      = uri http://duckduckgo.com/?q=\@-encodeURIComponent(%r)-\@
+@cbind  ddg<DuckDuckGo:>_      = uri https://duckduckgo.com/?q=\@-encodeURIComponent(%r)-\@
 # These bindings should be entered as simply \wiki but due to escaping
 # happening in multiple stages it needs to be written like this
 @cbind  \\\\awiki<Archwiki:>_  = uri http://wiki.archlinux.org/index.php/Special:Search?search=\@-encodeURIComponent(%r)-\@&go=Go


### PR DESCRIPTION
Particularly I missed `gg` and `G` in the default config. Searching DuckDuckGo was too many chars.

Google had to go - see comment - might not be in favor of everyone?

Please advise.
