### PR TITLE
increased key hint size and added borders

### DIFF
--- a/examples/config/style.css
+++ b/examples/config/style.css
@@ -3,11 +3,12 @@
 
     background-color:   #333           !important;
     margin:             0              !important;
-    padding:            3px            !important;
+    padding:            0 3px          !important;
+    border:             2px solid black  !important;
 
     color:              #ccc   !important;
-    font-size:          9px    !important;
-    line-height:        9px    !important;
+    font-size:          16px   !important;
+    line-height:        100%   !important;
     font-weight:        bold   !important;
     font-variant:       normal !important;
     text-decoration:    none   !important;
@@ -21,14 +22,15 @@
 
 /* we can have different colours for different types of hints! */
 #uzbl_link_hints.new-window > span {
-    background-color: #ffff00 !important;
-    color:            black   !important;
+    background-color: #ffff00          !important;
+    border:           2px solid green  !important;
+    color:            black            !important;
 }
 
 .uzbl-follow-text-match {
   outline: 2px solid invert;
-  background: #333 !important;
-  color: white !important;
+  background: #333                     !important;
+  color: white                         !important;
 }
 
 /* vim:set et ts=4: */


### PR DESCRIPTION
IMHO, a link hint size of `9px` is eye-strain tiny.

This commit contains some suggested improvements.