### PR TITLE
Interpret quotes in matcher for bind

### DIFF
--- a/examples/config/config
+++ b/examples/config/config
@@ -273,9 +273,9 @@ set history_disable_easter_egg 1
 @cbind  ^            = scroll horizontal begin
 @cbind  $            = scroll horizontal end
 @cbind  <Space>      = scroll vertical end
-@cbind  G<Go To:>_   = scroll vertical %r!
+@cbind  G<"Go To":>_   = scroll vertical %r!
 # The first '_' is literal, so type '_G' to trigger this binding.
-@cbind  _G<Go To:>_  = scroll horizontal %r!
+@cbind  _G<"Go To":>_  = scroll horizontal %r!
 
 # Frozen binding
 @cbind  <Shift><Ctrl>F  = toggle frozen
@@ -368,7 +368,7 @@ set history_disable_easter_egg 1
 # Go to the page in clipboard
 @cbind  P   = spawn_sh 'echo "uri $(xclip -selection clipboard -o | sed s/\\\@/%40/g)" > "$UZBL_FIFO"'
 # Start a new uzbl instance from the page in primary selection
-@cbind  'p  = spawn_sh 'echo "event REQ_NEW_WINDOW $(xclip -o)" > "$UZBL_FIFO"'
+@cbind  "'p"  = spawn_sh 'echo "event REQ_NEW_WINDOW $(xclip -o)" > "$UZBL_FIFO"'
 # paste primary selection into keycmd at the cursor position
 @bind <Shift><Insert> = spawn_sh 'echo "event INJECT_KEYCMD $(xclip -o | sed s/\\\@/%40/g)" > "$UZBL_FIFO"'
 
@@ -471,9 +471,9 @@ set formfiller spawn @scripts_dir/formfiller.sh
 
 # Preset loading
 set preset event PRESET_TABS
-@cbind  gs<preset save:>_   = @preset save %s
-@cbind  glo<preset load:>_  = @preset load %s
-@cbind  gd<preset del:>_    = @preset del %s
+@cbind  gs<"preset save":>_   = @preset save %s
+@cbind  glo<"preset load":>_  = @preset load %s
+@cbind  gd<"preset del":>_    = @preset del %s
 # This doesn't work right now.
 #@cbind  gli                 = @preset list
 

--- a/tests/event-manager/testbind.py
+++ b/tests/event-manager/testbind.py
@@ -48,4 +48,17 @@ class BindPluginTest(unittest.TestCase):
         b.parse_mode_bind('%s %s = %s' % (modes, glob, handler))
         binds = b.bindlet.get_binds()
         self.assertEqual(len(binds), 1)
+        self.assertEqual(binds[0].glob, glob)
+        self.assertEqual(binds[0].commands, [handler])
+
+    def test_parse_nasty_bind(self):
+        b = BindPlugin[self.uzbl]
+        modes = 'global'
+        glob = '\'x'
+        handler = 'do \'something\''
+
+        b.parse_mode_bind('%s "%s" = %s' % (modes, glob, handler))
+        binds = b.bindlet.get_binds()
+        self.assertEqual(len(binds), 1)
+        self.assertEqual(binds[0].glob, glob)
         self.assertEqual(binds[0].commands, [handler])

--- a/uzbl/plugins/bind.py
+++ b/uzbl/plugins/bind.py
@@ -375,7 +375,7 @@ class BindPlugin(PerInstancePlugin):
         modes = args[0].split(',')
         for i, g in enumerate(args[1:]):
             if g == '=':
-                glob = args.raw(1, i)
+                glob = ' '.join(args[1:i+1])
                 command = args.raw(i+2)
                 break
         else:


### PR DESCRIPTION
Restores the possibility to create binds containing special characters
like `'p` by quoting the string. Multiple parts of the matcher from
having spaces in the bind is combined but for clarity these are quoted
in the examples.