### PR TITLE
Interpret quotes in matcher for bind

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -54,6 +54,27 @@ selection, secondary selection, or clipboard through use of `primary`,
 known as `clipboard`.  The default behavior is now to copy to the
 actual clipboard, not the primary selection.
 
+## KEY BINDINGS
+
+`space` is no longer reported as a named special key but instead as a simple
+space character. Anything looking for `KEY_PRESS` event with `<space>` should
+be updated to look for `" "`
+
+The example event manager shipped with uzbl is stricter when parsing key bind
+events. In particular quote characters `['"]` are being interpreted.
+
+The bindings that was before written as
+```
+event MODE_BIND command <space> = spawn something.sh
+event MODE_BIND command 'p      = spawn other.sh
+```
+
+Is now written as
+```
+event MODE_BIND command " "  = spawn something.sh
+event MODE_BIND command "'p" = spawn other.sh
+```
+
 ## COMMANDS
 
 For 1.0, the commands in uzbl have been cleaned up. Some commands have

--- a/examples/config/config
+++ b/examples/config/config
@@ -181,7 +181,6 @@ set cookie_policy always
 #modmap <From>          <To>
 @modmap <Control>       <Ctrl>
 @modmap <ISO_Left_Tab>  <Shift-Tab>
-@modmap <space>         <Space>
 @modmap <KP_Enter>      <Enter>
 
 #ignore_key <glob>
@@ -272,7 +271,7 @@ set history_disable_easter_egg 1
 @cbind  <End>        = scroll vertical end
 @cbind  ^            = scroll horizontal begin
 @cbind  $            = scroll horizontal end
-@cbind  <Space>      = scroll vertical end
+@cbind  " "          = scroll vertical 100%
 @cbind  G<"Go To":>_   = scroll vertical %r!
 # The first '_' is literal, so type '_G' to trigger this binding.
 @cbind  _G<"Go To":>_  = scroll horizontal %r!

--- a/examples/config/config
+++ b/examples/config/config
@@ -273,9 +273,9 @@ set history_disable_easter_egg 1
 @cbind  ^            = scroll horizontal begin
 @cbind  $            = scroll horizontal end
 @cbind  <Space>      = scroll vertical end
-@cbind  G<Go To:>_   = scroll vertical %r!
+@cbind  G<"Go To":>_   = scroll vertical %r!
 # The first '_' is literal, so type '_G' to trigger this binding.
-@cbind  _G<Go To:>_  = scroll horizontal %r!
+@cbind  _G<"Go To":>_  = scroll horizontal %r!
 
 # Frozen binding
 @cbind  <Shift><Ctrl>F  = toggle frozen
@@ -368,7 +368,7 @@ set history_disable_easter_egg 1
 # Go to the page in clipboard
 @cbind  P   = spawn_sh 'echo "uri $(xclip -selection clipboard -o | sed s/\\\@/%40/g)" > "$UZBL_FIFO"'
 # Start a new uzbl instance from the page in primary selection
-@cbind  'p  = spawn_sh 'echo "event REQ_NEW_WINDOW $(xclip -o)" > "$UZBL_FIFO"'
+@cbind  "'p"  = spawn_sh 'echo "event REQ_NEW_WINDOW $(xclip -o)" > "$UZBL_FIFO"'
 # paste primary selection into keycmd at the cursor position
 @bind <Shift><Insert> = spawn_sh 'echo "event INJECT_KEYCMD $(xclip -o | sed s/\\\@/%40/g)" > "$UZBL_FIFO"'
 
@@ -471,9 +471,9 @@ set formfiller spawn @scripts_dir/formfiller.sh
 
 # Preset loading
 set preset event PRESET_TABS
-@cbind  gs<preset save:>_   = @preset save %s
-@cbind  glo<preset load:>_  = @preset load %s
-@cbind  gd<preset del:>_    = @preset del %s
+@cbind  gs<"preset save":>_   = @preset save %s
+@cbind  glo<"preset load":>_  = @preset load %s
+@cbind  gd<"preset del":>_    = @preset del %s
 # This doesn't work right now.
 #@cbind  gli                 = @preset list
 

--- a/tests/event-manager/testbind.py
+++ b/tests/event-manager/testbind.py
@@ -48,4 +48,17 @@ class BindPluginTest(unittest.TestCase):
         b.parse_mode_bind('%s %s = %s' % (modes, glob, handler))
         binds = b.bindlet.get_binds()
         self.assertEqual(len(binds), 1)
+        self.assertEqual(binds[0].glob, glob)
+        self.assertEqual(binds[0].commands, [handler])
+
+    def test_parse_nasty_bind(self):
+        b = BindPlugin[self.uzbl]
+        modes = 'global'
+        glob = '\'x'
+        handler = 'do \'something\''
+
+        b.parse_mode_bind('%s "%s" = %s' % (modes, glob, handler))
+        binds = b.bindlet.get_binds()
+        self.assertEqual(len(binds), 1)
+        self.assertEqual(binds[0].glob, glob)
         self.assertEqual(binds[0].commands, [handler])

--- a/uzbl/plugins/bind.py
+++ b/uzbl/plugins/bind.py
@@ -375,7 +375,7 @@ class BindPlugin(PerInstancePlugin):
         modes = args[0].split(',')
         for i, g in enumerate(args[1:]):
             if g == '=':
-                glob = args.raw(1, i)
+                glob = ' '.join(args[1:i+1])
                 command = args.raw(i+2)
                 break
         else:


### PR DESCRIPTION
Restores the possibility to create binds containing special characters
like `'p` by quoting the string. Multiple parts of the matcher from
having spaces in the bind is combined but for clarity these are quoted
in the examples.