### PR TITLE
Initial web extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -91,6 +91,8 @@ LOBJ  = $(foreach obj, $(SRC:.c=.lo), $(obj))
 PY    = $(wildcard uzbl/*.py uzbl/plugins/*.py)
 ICONS = icons/32x32.png icons/48x48.png icons/64x64.png icons/96x96.png
 
+webext_OBJ = src/uzbl-ext.lo
+
 all: uzbl-browser
 
 VPATH := src
@@ -100,6 +102,9 @@ ${OBJ}: ${HEAD}
 libuzbl.a: libuzbl.a(${OBJ})
 
 uzbl-core: libuzbl.a
+
+uzbl-ext.so: ${webext_OBJ}
+	$(CC) -shared $< -o $@
 
 uzbl-browser: uzbl-core uzbl-event-manager uzbl-browser.1 uzbl-core.desktop uzbl-tabbed.desktop bin/uzbl-browser
 
@@ -122,9 +127,9 @@ build: ${PY}
 .PHONY: uzbl-event-manager
 uzbl-event-manager: build
 
-# this is here because the .so needs to be compiled with -fPIC on x86_64
-${LOBJ}: ${SRC} ${HEAD}
-	$(CC) $(CPPFLAGS) $(CFLAGS) -fPIC -c src/$(@:.lo=.c) -o $@
+%.lo: ${HEAD}
+%.lo: %.c
+	$(CC) $(CPPFLAGS) $(CFLAGS) -fPIC -c $< -o $@
 
 .PHONY: tests
 tests: tests/core-tests

--- a/Makefile
+++ b/Makefile
@@ -62,7 +62,8 @@ SOURCES := \
     util.c \
     uzbl-core.c \
     variables.c \
-    3p/async-queue-source/rb-async-queue-watch.c
+    3p/async-queue-source/rb-async-queue-watch.c \
+    extio.c
 
 HEADERS := \
     comm.h \
@@ -82,7 +83,8 @@ HEADERS := \
     uzbl-core.h \
     variables.h \
     webkit.h \
-    3p/async-queue-source/rb-async-queue-watch.h
+    3p/async-queue-source/rb-async-queue-watch.h \
+    extio.h
 
 SRC   = $(addprefix src/,$(SOURCES))
 HEAD  = $(addprefix src/,$(HEADERS))
@@ -91,7 +93,7 @@ LOBJ  = $(foreach obj, $(SRC:.c=.lo), $(obj))
 PY    = $(wildcard uzbl/*.py uzbl/plugins/*.py)
 ICONS = icons/32x32.png icons/48x48.png icons/64x64.png icons/96x96.png
 
-webext_OBJ = src/uzbl-ext.lo
+webext_OBJ = src/uzbl-ext.lo src/extio.lo
 
 all: uzbl-browser
 
@@ -104,7 +106,7 @@ libuzbl.a: libuzbl.a(${OBJ})
 uzbl-core: libuzbl.a
 
 uzbl-ext.so: ${webext_OBJ}
-	$(CC) -shared $< -o $@
+	$(CC) -shared -fPIC $^ -o $@
 
 uzbl-browser: uzbl-core uzbl-event-manager uzbl-browser.1 uzbl-core.desktop uzbl-tabbed.desktop bin/uzbl-browser
 

--- a/src/events.h
+++ b/src/events.h
@@ -47,6 +47,8 @@
     call (DOWNLOAD_COMPLETE),   \
     call (ADD_COOKIE),          \
     call (DELETE_COOKIE),       \
+    call (FOCUS_ELEMENT),       \
+    call (BLUR_ELEMENT),        \
     call (WEB_PROCESS_CRASHED), \
     call (USER_EVENT),          \
     call (INSECURE_CONTENT),    \

--- a/src/extio.c
+++ b/src/extio.c
@@ -239,7 +239,7 @@ uzbl_extio_get_variant_type (ExtIOMessageType type)
 {
     switch (type) {
     case EXT_HELO:
-        return G_VARIANT_TYPE ("s");
+        return G_VARIANT_TYPE ("i");
     case EXT_FOCUS:
     case EXT_BLUR:
         return G_VARIANT_TYPE ("s");

--- a/src/extio.c
+++ b/src/extio.c
@@ -268,3 +268,34 @@ uzbl_extio_send_message (GOutputStream    *stream,
     g_variant_store (message, buf);
     g_output_stream_write (stream, buf, size, NULL, NULL);
 }
+
+GVariant *
+uzbl_extio_new_message (ExtIOMessageType type,
+                        ...)
+{
+    va_list vargs;
+    va_start (vargs, type);
+
+    const gchar *end;
+    const GVariantType *vt = uzbl_extio_get_variant_type (type);
+    const gchar *frmt = g_variant_type_peek_string (vt);
+    GVariant *var = g_variant_new_va (frmt, &end, &vargs);
+    g_variant_ref_sink (var);
+    va_end (vargs);
+
+    return var;
+}
+
+void
+uzbl_extio_get_message_data (ExtIOMessageType type,
+                             GVariant *var, ...)
+{
+    va_list vargs;
+    va_start (vargs, var);
+
+    const gchar *end;
+    const GVariantType *vt = uzbl_extio_get_variant_type (type);
+    const gchar *frmt = g_variant_type_peek_string (vt);
+    g_variant_get_va (var, frmt, &end, &vargs);
+    va_end (vargs);
+}

--- a/src/extio.c
+++ b/src/extio.c
@@ -1,0 +1,267 @@
+#include "extio.h"
+#include "util.h"
+
+#define HEADER_SIZE 8
+
+static void
+read_header_async (GInputStream        *stream,
+                   GAsyncReadyCallback  callback,
+                   gpointer             user_data);
+static GVariant*
+read_header_finish (GInputStream  *stream,
+                    GAsyncResult  *result,
+                    GError       **error);
+static void
+read_payload_async (GInputStream        *stream,
+                    ExtIOMessageType     type,
+                    gsize                size,
+                    GAsyncReadyCallback  callback,
+                    gpointer             user_data);
+static GVariant*
+read_payload_finish (GInputStream      *stream,
+                     GAsyncResult      *result,
+                     ExtIOMessageType  *messagetype,
+                     GError           **error);
+
+static void
+read_header_read_all_cb (GObject      *source,
+                         GAsyncResult *res,
+                         gpointer      user_data);
+
+void
+read_header_async (GInputStream        *stream,
+                   GAsyncReadyCallback  callback,
+                   gpointer             user_data)
+{
+    void *buffer = g_malloc (HEADER_SIZE);
+    GTask *task = g_task_new (stream, NULL, callback, user_data);
+
+    g_task_set_task_data (task, buffer, g_free);
+
+    g_input_stream_read_all_async (stream, buffer, HEADER_SIZE,
+                                   G_PRIORITY_DEFAULT,
+                                   NULL,
+                                   read_header_read_all_cb,
+                                   task);
+}
+
+void
+read_header_read_all_cb (GObject      *source,
+                         GAsyncResult *res,
+                         gpointer      user_data)
+{
+    GInputStream *stream = G_INPUT_STREAM (source);
+    GTask *task = G_TASK (user_data);
+    gsize read;
+    GError *error;
+    void *buffer = g_task_get_task_data (task);
+
+    if (!g_input_stream_read_all_finish (stream, res, &read, &error)) {
+        g_task_return_error (task, error);
+        return;
+    }
+
+    const GVariantType *type = g_variant_type_new ("(ii)");
+    GVariant *var = g_variant_new_from_data (type, buffer, read, FALSE,
+                                             NULL, NULL);
+
+    g_task_return_pointer (task, var, NULL);
+}
+
+GVariant*
+read_header_finish (GInputStream  *stream,
+                    GAsyncResult  *result,
+                    GError       **error)
+{
+    UZBL_UNUSED (stream);
+    GTask *task = G_TASK (result);
+
+    return (GVariant*) g_task_propagate_pointer (task, error);
+}
+
+
+typedef struct _ReadPayloadData ReadPayloadData;
+struct _ReadPayloadData {
+    ExtIOMessageType type;
+    void *buffer;
+};
+
+static void
+read_payload_read_all_cb (GObject      *source,
+                          GAsyncResult *res,
+                          gpointer      user_data);
+static void
+read_payload_data_free (gpointer data);
+
+void
+read_payload_async (GInputStream        *stream,
+                    ExtIOMessageType     type,
+                    gsize                size,
+                    GAsyncReadyCallback  callback,
+                    gpointer             user_data)
+{
+    ReadPayloadData *data = g_slice_new (ReadPayloadData);
+    data->buffer = g_malloc (size);
+    data->type = type;
+
+    GTask *task = g_task_new (stream, NULL, callback, user_data);
+    g_task_set_task_data (task, data, read_payload_data_free);
+    g_input_stream_read_all_async (stream, data->buffer, size,
+                                   G_PRIORITY_DEFAULT,
+                                   NULL,
+                                   read_payload_read_all_cb,
+                                   task);
+}
+
+void
+read_payload_data_free (gpointer data)
+{
+    ReadPayloadData *rpd = (ReadPayloadData*)data;
+    g_free (rpd->buffer);
+    g_slice_free (ReadPayloadData, rpd);
+}
+
+void
+read_payload_read_all_cb (GObject      *source,
+                          GAsyncResult *res,
+                          gpointer      user_data)
+{
+    GInputStream *stream = G_INPUT_STREAM (source);
+    GTask *task = G_TASK (user_data);
+    gsize read;
+    GError *error = NULL;
+    ReadPayloadData *data = g_task_get_task_data (task);
+
+    if (!g_input_stream_read_all_finish (stream, res, &read, &error)) {
+        g_task_return_error (task, error);
+        return;
+    }
+
+    const GVariantType *type = uzbl_extio_get_variant_type (data->type);
+    GVariant *var = g_variant_new_from_data (type, data->buffer, read, FALSE,
+                                             NULL, NULL);
+    g_task_return_pointer (task, var, NULL);
+}
+
+GVariant*
+read_payload_finish (GInputStream      *stream,
+                     GAsyncResult      *result,
+                     ExtIOMessageType  *messagetype,
+                     GError           **error)
+{
+    UZBL_UNUSED (stream);
+    GTask *task = G_TASK (result);
+    ReadPayloadData *data = g_task_get_task_data (task);
+
+    *messagetype = data->type;
+    return (GVariant*) g_task_propagate_pointer (task, error);
+}
+
+static void
+read_header_cb (GObject      *source,
+                GAsyncResult *res,
+                gpointer      user_data);
+static void
+read_payload_cb (GObject     *source,
+                GAsyncResult *res,
+                gpointer      user_data);
+
+void
+uzbl_extio_read_message_async (GInputStream        *stream,
+                               GAsyncReadyCallback  callback,
+                               gpointer             user_data)
+{
+    GTask *task = g_task_new (stream, NULL, callback, user_data);
+
+    read_header_async (stream, read_header_cb, (gpointer) task);
+}
+
+void
+read_header_cb (GObject      *source,
+                GAsyncResult *res,
+                gpointer      user_data)
+{
+    GInputStream *stream = G_INPUT_STREAM (source);
+    GTask *task = G_TASK (user_data);
+
+    GError *error = NULL;
+
+    GVariant *header;
+
+    if (!(header = read_header_finish (stream, res, &error))) {
+        g_task_return_error (task, error);
+        return;
+    }
+
+    gint32 type;
+    gint32 size;
+
+    g_variant_get (header, "(ii)", &type, &size);
+    UZBL_UNUSED (type);
+    read_payload_async (stream, type, size, read_payload_cb, (gpointer) task);
+}
+
+void
+read_payload_cb (GObject     *source,
+                GAsyncResult *res,
+                gpointer      user_data)
+{
+    GInputStream *stream = G_INPUT_STREAM (source);
+    GTask *task = G_TASK (user_data);
+    GError *error = NULL;
+    ExtIOMessageType messagetype;
+    GVariant *var;
+
+    if (!(var = read_payload_finish (stream, res, &messagetype, &error))) {
+        g_task_return_error (task, error);
+        return;
+    }
+
+    g_task_set_task_data (task, GINT_TO_POINTER (messagetype), NULL);
+    g_task_return_pointer (task, var, g_free);
+}
+
+GVariant *
+uzbl_extio_read_message_finish (GInputStream      *stream,
+                                GAsyncResult      *result,
+                                ExtIOMessageType  *messagetype,
+                                GError           **error)
+{
+    UZBL_UNUSED (stream);
+    GTask *task = G_TASK (result);
+
+    *messagetype = GPOINTER_TO_INT (g_task_get_task_data (task));
+    return (GVariant*) g_task_propagate_pointer (task, error);
+}
+
+const GVariantType *
+uzbl_extio_get_variant_type (ExtIOMessageType type)
+{
+    switch (type) {
+    case EXT_HELO:
+        return G_VARIANT_TYPE ("s");
+    }
+
+    return 0;
+}
+
+void
+uzbl_extio_send_message (GOutputStream    *stream,
+                         ExtIOMessageType  type,
+                         GVariant         *message)
+{
+    gsize size = g_variant_get_size (message);
+    GVariant *header = g_variant_new ("(ii)", type, size);
+
+    gsize headersize = g_variant_get_size (header);
+    gchar *buf = g_malloc (headersize);
+    g_variant_store (header, buf);
+
+    g_output_stream_write (stream, buf, headersize, NULL, NULL);
+    g_variant_unref (header);
+    g_free (buf);
+
+    buf = g_malloc (size);
+    g_variant_store (message, buf);
+    g_output_stream_write (stream, buf, size, NULL, NULL);
+}

--- a/src/extio.c
+++ b/src/extio.c
@@ -240,6 +240,9 @@ uzbl_extio_get_variant_type (ExtIOMessageType type)
     switch (type) {
     case EXT_HELO:
         return G_VARIANT_TYPE ("s");
+    case EXT_FOCUS:
+    case EXT_BLUR:
+        return G_VARIANT_TYPE ("s");
     }
 
     return 0;

--- a/src/extio.h
+++ b/src/extio.h
@@ -1,6 +1,8 @@
 #include <glib.h>
 #include <gio/gio.h>
 
+#define EXTIO_PROTOCOL 1
+
 typedef enum {
     EXT_HELO,
     EXT_FOCUS,

--- a/src/extio.h
+++ b/src/extio.h
@@ -2,7 +2,9 @@
 #include <gio/gio.h>
 
 typedef enum {
-    EXT_HELO
+    EXT_HELO,
+    EXT_FOCUS,
+    EXT_BLUR
 } ExtIOMessageType;
 
 void

--- a/src/extio.h
+++ b/src/extio.h
@@ -1,0 +1,25 @@
+#include <glib.h>
+#include <gio/gio.h>
+
+typedef enum {
+    EXT_HELO
+} ExtIOMessageType;
+
+void
+uzbl_extio_read_message_async (GInputStream        *stream,
+                               GAsyncReadyCallback  callback,
+                               gpointer             user_data);
+
+GVariant *
+uzbl_extio_read_message_finish (GInputStream      *stream,
+                                GAsyncResult      *result,
+                                ExtIOMessageType  *messagetype,
+                                GError           **error);
+
+const GVariantType *
+uzbl_extio_get_variant_type (ExtIOMessageType type);
+
+void
+uzbl_extio_send_message (GOutputStream    *stream,
+                         ExtIOMessageType  type,
+                         GVariant         *message);

--- a/src/extio.h
+++ b/src/extio.h
@@ -27,3 +27,10 @@ void
 uzbl_extio_send_message (GOutputStream    *stream,
                          ExtIOMessageType  type,
                          GVariant         *message);
+
+GVariant *
+uzbl_extio_new_message (ExtIOMessageType type, ...);
+
+void
+uzbl_extio_get_message_data (ExtIOMessageType type,
+                             GVariant *var, ...);

--- a/src/gui.c
+++ b/src/gui.c
@@ -242,7 +242,13 @@ initialize_web_extensions (WebKitWebContext *context, gpointer user_data)
 {
     UZBL_UNUSED (user_data);
 
-    GVariant *data = g_variant_new ("s", "Uzbl!");
+    int in;
+    int out;
+
+    uzbl_io_init_extpipe ();
+    uzbl_io_extfds (&in, &out);
+
+    GVariant *data = g_variant_new ("(sxx)", "Uzbl!", in, out);
     webkit_web_context_set_web_extensions_initialization_user_data (
         context,
         data

--- a/src/gui.c
+++ b/src/gui.c
@@ -9,6 +9,7 @@
 #include "util.h"
 #include "uzbl-core.h"
 #include "variables.h"
+#include "extio.h"
 
 #include <gtk/gtkimcontextsimple.h>
 
@@ -248,7 +249,7 @@ initialize_web_extensions (WebKitWebContext *context, gpointer user_data)
     uzbl_io_init_extpipe ();
     uzbl_io_extfds (&in, &out);
 
-    GVariant *data = g_variant_new ("(sxx)", "Uzbl!", in, out);
+    GVariant *data = g_variant_new ("(ixx)", EXTIO_PROTOCOL, in, out);
     webkit_web_context_set_web_extensions_initialization_user_data (
         context,
         data

--- a/src/gui.c
+++ b/src/gui.c
@@ -195,6 +195,9 @@ status_bar_init ()
       */
 }
 
+static void
+initialize_web_extensions (WebKitWebContext *context, gpointer user_data);
+
 WebKitWebContext*
 create_web_context (const gchar *cache_dir,
                     const gchar *data_dir,
@@ -227,7 +230,23 @@ create_web_context (const gchar *cache_dir,
 #endif
     webkit_web_context_set_web_extensions_directory (webkit_context, web_extensions_dir);
 
+
+    g_signal_connect (webkit_context, "initialize-web-extensions",
+                      G_CALLBACK (initialize_web_extensions), NULL);
+
     return webkit_context;
+}
+
+void
+initialize_web_extensions (WebKitWebContext *context, gpointer user_data)
+{
+    UZBL_UNUSED (user_data);
+
+    GVariant *data = g_variant_new ("s", "Uzbl!");
+    webkit_web_context_set_web_extensions_initialization_user_data (
+        context,
+        data
+    );
 }
 
 /* Mouse events */

--- a/src/io.c
+++ b/src/io.c
@@ -762,7 +762,7 @@ read_message_cb (GObject *source,
     case EXT_HELO:
         {
             gint proto;
-            g_variant_get (message, "i", &proto);
+            uzbl_extio_get_message_data (EXT_HELO, message, &proto);
             if (proto != EXTIO_PROTOCOL) {
                 g_warning ("Extension with incompatible version loaded (expected %d, was %d)", EXTIO_PROTOCOL, proto);
                 gtk_main_quit ();
@@ -772,7 +772,7 @@ read_message_cb (GObject *source,
     case EXT_FOCUS:
         {
             gchar *name;
-            g_variant_get (message, "s", &name);
+            uzbl_extio_get_message_data (EXT_FOCUS, message, &name);
             uzbl_events_send (FOCUS_ELEMENT, NULL,
                               TYPE_STR, name,
                               NULL);
@@ -782,7 +782,7 @@ read_message_cb (GObject *source,
     case EXT_BLUR:
         {
             gchar *name;
-            g_variant_get (message, "s", &name);
+            uzbl_extio_get_message_data (EXT_BLUR, message, &name);
             uzbl_events_send (BLUR_ELEMENT, NULL,
                               TYPE_STR, name,
                               NULL);

--- a/src/io.c
+++ b/src/io.c
@@ -767,6 +767,26 @@ read_message_cb (GObject *source,
             g_free (str);
             break;
         }
+    case EXT_FOCUS:
+        {
+            gchar *name;
+            g_variant_get (message, "s", &name);
+            uzbl_events_send (FOCUS_ELEMENT, NULL,
+                              TYPE_STR, name,
+                              NULL);
+            g_free (name);
+            break;
+        }
+    case EXT_BLUR:
+        {
+            gchar *name;
+            g_variant_get (message, "s", &name);
+            uzbl_events_send (BLUR_ELEMENT, NULL,
+                              TYPE_STR, name,
+                              NULL);
+            g_free (name);
+            break;
+        }
     default:
         {
             gchar *pmsg = g_variant_print (message, TRUE);

--- a/src/io.c
+++ b/src/io.c
@@ -761,10 +761,12 @@ read_message_cb (GObject *source,
     switch (messagetype) {
     case EXT_HELO:
         {
-            gchar *str;
-            g_variant_get (message, "s", &str);
-            g_debug ("extension connected, %s", str);
-            g_free (str);
+            gint proto;
+            g_variant_get (message, "i", &proto);
+            if (proto != EXTIO_PROTOCOL) {
+                g_warning ("Extension with incompatible version loaded (expected %d, was %d)", EXTIO_PROTOCOL, proto);
+                gtk_main_quit ();
+            }
             break;
         }
     case EXT_FOCUS:

--- a/src/io.h
+++ b/src/io.h
@@ -17,5 +17,9 @@ gboolean
 uzbl_io_init_fifo (const gchar *dir);
 gboolean
 uzbl_io_init_socket (const gchar *dir);
+gboolean
+uzbl_io_init_extpipe ();
+void
+uzbl_io_extfds(int *input, int *output);
 
 #endif

--- a/src/uzbl-ext.c
+++ b/src/uzbl-ext.c
@@ -1,0 +1,45 @@
+#include <webkit2/webkit-web-extension.h>
+#include "uzbl-ext.h"
+#define UZBL_UNUSED(var) (void)var
+
+struct _UzblExt {
+};
+
+UzblExt*
+uzbl_ext_new ()
+{
+    UzblExt *ext = g_new (UzblExt, 1);
+    return ext;
+}
+
+static void
+web_page_created_callback (WebKitWebExtension *extension,
+                           WebKitWebPage      *web_page,
+                           gpointer            user_data);
+
+G_MODULE_EXPORT void
+webkit_web_extension_initialize_with_user_data (WebKitWebExtension *extension,
+                                                GVariant           *user_data)
+{
+    gchar *pretty_data = g_variant_print (user_data, TRUE);
+    g_debug ("Initializing web extension with %s", pretty_data);
+    g_free (pretty_data);
+
+    UzblExt *ext = uzbl_ext_new ();
+
+    g_signal_connect (extension, "page-created",
+                      G_CALLBACK (web_page_created_callback),
+                      ext);
+}
+
+void
+web_page_created_callback (WebKitWebExtension *extension,
+                           WebKitWebPage      *web_page,
+                           gpointer            user_data)
+{
+    UZBL_UNUSED (extension);
+    UZBL_UNUSED (web_page);
+    UZBL_UNUSED (user_data);
+
+    g_debug ("Web page created");
+}

--- a/src/uzbl-ext.c
+++ b/src/uzbl-ext.c
@@ -151,7 +151,7 @@ dom_focus_callback (WebKitDOMEventTarget *target,
     WebKitDOMEventTarget *etarget = webkit_dom_event_get_target (event);
     gchar *name = webkit_dom_node_get_node_name (WEBKIT_DOM_NODE (etarget));
 
-    GVariant *message = g_variant_new ("s", name);
+    GVariant *message = uzbl_extio_new_message (EXT_FOCUS, name);
     uzbl_extio_send_message (g_io_stream_get_output_stream (ext->stream),
                              EXT_FOCUS, message);
     g_variant_unref (message);
@@ -168,7 +168,7 @@ dom_blur_callback (WebKitDOMEventTarget *target,
     WebKitDOMEventTarget *etarget = webkit_dom_event_get_target (event);
     gchar *name = webkit_dom_node_get_node_name (WEBKIT_DOM_NODE (etarget));
 
-    GVariant *message = g_variant_new ("s", name);
+    GVariant *message = uzbl_extio_new_message (EXT_FOCUS, name);
     uzbl_extio_send_message (g_io_stream_get_output_stream (ext->stream),
                              EXT_BLUR, message);
     g_variant_unref (message);

--- a/src/uzbl-ext.h
+++ b/src/uzbl-ext.h
@@ -1,0 +1,4 @@
+typedef struct _UzblExt UzblExt;
+
+UzblExt*
+uzbl_ext_new ();

--- a/src/uzbl-ext.h
+++ b/src/uzbl-ext.h
@@ -2,3 +2,6 @@ typedef struct _UzblExt UzblExt;
 
 UzblExt*
 uzbl_ext_new ();
+
+static void
+uzbl_ext_init_io (UzblExt *ext, int in, int out);


### PR DESCRIPTION
Very rough draft of a web extension with a system for passing strictly typed messages over a pair of pipes.

I used gvariant here to avoid having to deal with the command language between core and extension. It does more than we really need for this and it would make it harder to change that language later on.

The idea is that the message handler (that would exist on both sides) would have switch on the enum of message types and then do different g_variant_get calls to extract the values e.g

in core
```
case EXT_FOCUS_ELEMENT:
    gchar *type, *id;
    g_variant_get (var, "(ss)", &type, &id);
```

or -

in extension
```
case EXT_EVAL_JAVASCRIPT:
    gchar *source, *tag;
    gint context;
    g_variant_get (var, "(ssi)", &source, &tag, &context);
```

- [x] Tidy up build system
- [x] Avoid repeating format strings