### PR TITLE
No empty strings in parser

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,22 @@
+dist: trusty
+sudo: required
 language: python
 python:
     - "2.7"
     - "3.3"
     - "3.4"
     - "pypy"
+addons:
+  apt:
+    sources:
+      - debian-sid
+    packages:
+      - libglib2.0-dev
+      - libwebkitgtk-dev
 install:
     - pip install six nose mock coveralls
     - python -c 'import configparser' || pip install configparser
 script:
-    nosetests tests/event-manager --with-coverage --cover-package=uzbl
+    - make tests && nosetests tests/event-manager --with-coverage --cover-package=uzbl
 after_success:
     coveralls
-sudo: false

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,9 @@ VPATH := src
 
 ${OBJ}: ${HEAD}
 
-uzbl-core: ${OBJ}
+libuzbl.a: libuzbl.a(${OBJ})
+
+uzbl-core: libuzbl.a
 
 uzbl-browser: uzbl-core uzbl-event-manager uzbl-browser.1 uzbl-core.desktop uzbl-tabbed.desktop bin/uzbl-browser
 
@@ -140,6 +142,12 @@ uzbl-event-manager: build
 # this is here because the .so needs to be compiled with -fPIC on x86_64
 ${LOBJ}: ${SRC} ${HEAD}
 	$(CC) $(CPPFLAGS) $(CFLAGS) -fPIC -c src/$(@:.lo=.c) -o $@
+
+.PHONY: tests
+tests: tests/core-tests
+	tests/core-tests
+
+tests/core-tests: tests/core-tests.o libuzbl.a
 
 test-uzbl-core: uzbl-core
 	./uzbl-core http://www.uzbl.org --verbose

--- a/src/commands.c
+++ b/src/commands.c
@@ -465,44 +465,52 @@ split_quoted (const gchar *src, const gboolean unquote)
 
     GArray *argv = uzbl_commands_args_new ();
     GString *str = g_string_new ("");
-    const gchar *p;
+    const gchar *p = src;
 
     gboolean ctx_double_quote = FALSE;
     gboolean ctx_single_quote = FALSE;
 
-    for (p = src; *p; ++p) {
+    // Strip leading whitespace
+    while (isspace(*p)) {
+        ++p;
+    }
+
+    while (*p) {
         if ((*p == '\\') && p[1]) {
             /* Escaped character. */
             if (unquote) {
                 g_string_append_c (str, *++p);
             } else {
                 g_string_append_c (str, *p++);
-                g_string_append_c (str, *p);
+                g_string_append_c (str, *p++);
             }
         } else if ((*p == '"') && !ctx_single_quote) {
             /* Double quoted argument. */
             if (unquote) {
                 ctx_double_quote = !ctx_double_quote;
+                ++p;
             } else {
-                g_string_append_c (str, *p);
+                g_string_append_c (str, *p++);
                 ctx_double_quote = !ctx_double_quote;
             }
         } else if ((*p == '\'') && !ctx_double_quote) {
             /* Single quoted argument. */
             if (unquote) {
                 ctx_single_quote = !ctx_single_quote;
+                ++p;
             } else {
-                g_string_append_c (str, *p);
+                g_string_append_c (str, *p++);
                 ctx_single_quote = ! ctx_single_quote;
             }
         } else if (isspace (*p) && !ctx_double_quote && !ctx_single_quote) {
             /* Argument separator. */
-            /* FIXME: Is "a  b" three arguments? */
+            while (isspace(*++p));
+
             uzbl_commands_args_append (argv, g_strdup (str->str));
             g_string_truncate (str, 0);
         } else {
             /* Regular character. */
-            g_string_append_c (str, *p);
+            g_string_append_c (str, *p++);
         }
     }
 

--- a/src/uzbl-core.c
+++ b/src/uzbl-core.c
@@ -471,7 +471,6 @@ get_xdg_var (gboolean user, XdgDir dir)
     return str_replace("~", home, actual_value);
 }
 
-#ifndef UZBL_LIBRARY
 gchar *
 find_xdg_file (XdgDir dir, const char* basename)
 {
@@ -497,4 +496,3 @@ find_xdg_file (XdgDir dir, const char* basename)
 
     return path;
 }
-#endif

--- a/tests/core-tests.c
+++ b/tests/core-tests.c
@@ -1,0 +1,59 @@
+#include <glib.h>
+
+#include "../src/uzbl-core.h"
+
+#include "../src/setup.h"
+#include "../src/commands.h"
+
+UzblCore uzbl;
+
+static void
+test_parse_simple ()
+{
+    GArray *argv = uzbl_commands_args_new ();
+    const UzblCommand *cmd = uzbl_commands_parse ("toggle foo bar baz", argv);
+    g_assert_nonnull (cmd);
+    g_assert_cmpint (3, ==, argv->len);
+    g_assert_cmpstr (g_array_index (argv, gchar*, 0), ==, "foo");
+    g_assert_cmpstr (g_array_index (argv, gchar*, 1), ==, "bar");
+    g_assert_cmpstr (g_array_index (argv, gchar*, 2), ==, "baz");
+}
+
+static void
+test_parse_quoted ()
+{
+    GArray *argv = uzbl_commands_args_new ();
+    const UzblCommand *cmd = uzbl_commands_parse ("toggle foo bar 'a quoted string'", argv);
+    g_assert_nonnull (cmd);
+    g_assert_cmpint (3, ==, argv->len);
+    g_assert_cmpstr (g_array_index (argv, gchar*, 0), ==, "foo");
+    g_assert_cmpstr (g_array_index (argv, gchar*, 1), ==, "bar");
+    g_assert_cmpstr (g_array_index (argv, gchar*, 2), ==, "a quoted string");
+}
+
+static void
+test_parse_extra_whitespace ()
+{
+    GArray *argv = uzbl_commands_args_new ();
+    const UzblCommand *cmd = uzbl_commands_parse ("toggle  foo  bar  baz", argv);
+
+    g_assert_nonnull (cmd);
+    g_assert_cmpint (3, ==, argv->len);
+    g_assert_cmpstr (g_array_index (argv, gchar*, 0), ==, "foo");
+    g_assert_cmpstr (g_array_index (argv, gchar*, 1), ==, "bar");
+    g_assert_cmpstr (g_array_index (argv, gchar*, 2), ==, "baz");
+}
+
+int
+main (int argc, char *argv[])
+{
+    g_test_init (&argc, &argv, NULL);
+
+    uzbl_commands_init ();
+
+    g_test_add_func ("/uzbl/commands/parse_simple", test_parse_simple);
+    g_test_add_func ("/uzbl/commands/parse_quoted", test_parse_quoted);
+    g_test_add_func ("/uzbl/commands/parse_extra_whitespace", test_parse_extra_whitespace);
+
+    return g_test_run ();
+}


### PR DESCRIPTION
Extracted from #252 

* No more empty strings in parsed array from consecutive whitespace
* Drop unquote option and make it the default behaviour, it was always set to TRUE 