### PR TITLE
Streamline usage of ext messages

### DIFF
--- a/src/extio.h
+++ b/src/extio.h
@@ -1,3 +1,6 @@
+#ifndef UZBL_EXTIO_H
+#define UZBL_EXTIO_H
+
 #include <glib.h>
 #include <gio/gio.h>
 
@@ -28,9 +31,24 @@ uzbl_extio_send_message (GOutputStream    *stream,
                          ExtIOMessageType  type,
                          GVariant         *message);
 
+void
+uzbl_extio_send_new_messagev (GOutputStream    *stream,
+                              ExtIOMessageType  type,
+                              va_list *vargs);
+void
+uzbl_extio_send_new_message (GOutputStream    *stream,
+                             ExtIOMessageType  type,
+                             ...);
+
+GVariant *
+uzbl_extio_new_messagev (ExtIOMessageType type,
+                         va_list *vargs);
+
 GVariant *
 uzbl_extio_new_message (ExtIOMessageType type, ...);
 
 void
 uzbl_extio_get_message_data (ExtIOMessageType type,
                              GVariant *var, ...);
+
+#endif

--- a/src/io.c
+++ b/src/io.c
@@ -229,6 +229,16 @@ uzbl_io_schedule_command (const UzblCommand *cmd, GArray *argv, UzblIOCallback c
     g_async_queue_push (uzbl.io->cmd_q, cmd_data);
 }
 
+void
+uzbl_io_send_ext_message (ExtIOMessageType type, ...)
+{
+    va_list vargs;
+    va_start (vargs, type);
+    GOutputStream *os = g_io_stream_get_output_stream (uzbl.io->extstream);
+    uzbl_extio_send_new_messagev (os, type, &vargs);
+    va_end (vargs);
+}
+
 typedef enum {
     UZBL_COMM_FIFO,
     UZBL_COMM_SOCKET

--- a/src/io.h
+++ b/src/io.h
@@ -2,6 +2,7 @@
 #define UZBL_IO_H
 
 #include "commands.h"
+#include "extio.h"
 
 #include <glib.h>
 
@@ -12,6 +13,8 @@ typedef void (*UzblIOCallback)(GString *result, gpointer data);
 
 void
 uzbl_io_schedule_command (const UzblCommand *cmd, GArray *argv, UzblIOCallback callback, gpointer data);
+void
+uzbl_io_send_ext_message (ExtIOMessageType type, ...);
 
 gboolean
 uzbl_io_init_fifo (const gchar *dir);

--- a/src/uzbl-ext.c
+++ b/src/uzbl-ext.c
@@ -98,10 +98,8 @@ webkit_web_extension_initialize_with_user_data (WebKitWebExtension *extension,
     g_variant_get (user_data, "(ixx)", &proto, &in, &out);
     uzbl_ext_init_io (ext, in, out);
 
-    GVariant *message = g_variant_new ("i", EXTIO_PROTOCOL);
-    uzbl_extio_send_message (g_io_stream_get_output_stream (ext->stream),
-                             EXT_HELO, message);
-    g_variant_unref (message);
+    uzbl_extio_send_new_message (g_io_stream_get_output_stream (ext->stream),
+                                 EXT_HELO, EXTIO_PROTOCOL);
 
     if (proto != EXTIO_PROTOCOL) {
         g_warning ("Extension loaded into incompatible version of uzbl (expected %d, was %d)", EXTIO_PROTOCOL, proto);
@@ -151,10 +149,8 @@ dom_focus_callback (WebKitDOMEventTarget *target,
     WebKitDOMEventTarget *etarget = webkit_dom_event_get_target (event);
     gchar *name = webkit_dom_node_get_node_name (WEBKIT_DOM_NODE (etarget));
 
-    GVariant *message = uzbl_extio_new_message (EXT_FOCUS, name);
-    uzbl_extio_send_message (g_io_stream_get_output_stream (ext->stream),
-                             EXT_FOCUS, message);
-    g_variant_unref (message);
+    uzbl_extio_send_new_message (g_io_stream_get_output_stream (ext->stream),
+                                 EXT_FOCUS, name);
 }
 
 void
@@ -168,8 +164,6 @@ dom_blur_callback (WebKitDOMEventTarget *target,
     WebKitDOMEventTarget *etarget = webkit_dom_event_get_target (event);
     gchar *name = webkit_dom_node_get_node_name (WEBKIT_DOM_NODE (etarget));
 
-    GVariant *message = uzbl_extio_new_message (EXT_FOCUS, name);
-    uzbl_extio_send_message (g_io_stream_get_output_stream (ext->stream),
-                             EXT_BLUR, message);
-    g_variant_unref (message);
+    uzbl_extio_send_new_message (g_io_stream_get_output_stream (ext->stream),
+                                 EXT_BLUR, name);
 }


### PR DESCRIPTION
Add convenience wrapper for formatting and sending message and interface
to io in core to send message to extension.

Still todo is some way to get a response back I'm thinking it should be possible to reuse some parts of requests.c for that. That'll be a later PR though.