### PR TITLE
Async js command

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -2153,7 +2153,7 @@ run_js_cb (GObject      *source,
 
 IMPLEMENT_TASK (js)
 {
-    //ARG_CHECK (argv, 3);
+    TASK_ARG_CHECK (task, argv, 3);
 
     const gchar *context = argv_idx (argv, 0);
     const gchar *where = argv_idx (argv, 1);

--- a/src/commands.h
+++ b/src/commands.h
@@ -2,6 +2,7 @@
 #define UZBL_COMMANDS_H
 
 #include <glib.h>
+#include <gio/gio.h>
 
 struct _UzblCommand;
 typedef struct _UzblCommand UzblCommand;
@@ -17,6 +18,16 @@ const UzblCommand *
 uzbl_commands_parse (const gchar *cmd, GArray *argv);
 void
 uzbl_commands_run_parsed (const UzblCommand *info, GArray *argv, GString *result);
+void
+uzbl_commands_run_async (const UzblCommand   *info,
+                         GArray              *argv,
+                         gboolean             capture,
+                         GAsyncReadyCallback  callback,
+                         gpointer             data);
+GString*
+uzbl_commands_run_finish (GObject       *source,
+                          GAsyncResult  *res,
+                          GError       **error);
 void
 uzbl_commands_run_argv (const gchar *cmd, GArray *argv, GString *result);
 void

--- a/src/js.c
+++ b/src/js.c
@@ -1,10 +1,73 @@
 #include "js.h"
 #include "uzbl-core.h"
+#include "util.h"
 
 #include <stdlib.h>
 
-/* =========================== PUBLIC API =========================== */
+static JSValueRef
+uzbl_js_evaluate(JSGlobalContextRef   jsctx,
+                 const gchar         *script,
+                 const gchar         *path,
+                 GError             **err)
+{
+    JSObjectRef globalobject = JSContextGetGlobalObject (jsctx);
+    JSValueRef js_exc = NULL;
 
+    JSStringRef js_script = JSStringCreateWithUTF8CString (script);
+    JSStringRef js_file = JSStringCreateWithUTF8CString (path);
+    JSValueRef js_result = JSEvaluateScript (jsctx, js_script, globalobject, js_file, 0, &js_exc);
+
+    if (js_exc) {
+        JSObjectRef exc = JSValueToObject (jsctx, js_exc, NULL);
+
+        gchar *file = uzbl_js_to_string (jsctx, uzbl_js_get (jsctx, exc, "sourceURL"));
+        gchar *line = uzbl_js_to_string (jsctx, uzbl_js_get (jsctx, exc, "line"));
+        gchar *msg = uzbl_js_to_string (jsctx, exc);
+
+        g_set_error (err, UZBL_JS_ERROR, UZBL_JS_ERROR_EVAL,
+                     "%s:%s: %s",
+                     file, line, msg);
+
+        g_free (file);
+        g_free (line);
+        g_free (msg);
+    }
+
+    JSStringRelease (js_file);
+    JSStringRelease (js_script);
+
+    return js_result;
+}
+
+static JSGlobalContextRef
+uzbl_js_get_context(UzblJSContext context)
+{
+    JSGlobalContextRef jsctx;
+
+    switch (context) {
+    case JSCTX_UZBL:
+        jsctx = uzbl.state.jscontext;
+        JSGlobalContextRetain (jsctx);
+        break;
+    case JSCTX_CLEAN:
+        jsctx = JSGlobalContextCreate (NULL);
+        break;
+    case JSCTX_PAGE:
+        /* TODO: This doesn't seem to be the right thing... */
+        jsctx = webkit_web_view_get_javascript_global_context (uzbl.gui.web_view);
+
+        if (!jsctx) {
+            uzbl_debug ("Failed to get the javascript context\n");
+            return jsctx;
+        }
+
+        JSGlobalContextRetain (jsctx);
+    }
+
+    return jsctx;
+}
+
+/* =========================== PUBLIC API =========================== */
 void
 uzbl_js_init ()
 {
@@ -18,13 +81,10 @@ uzbl_js_init ()
         kJSPropertyAttributeReadOnly | kJSPropertyAttributeDontDelete);
 }
 
-JSObjectRef
-uzbl_js_object (JSContextRef ctx, const gchar *prop)
+GQuark
+uzbl_js_error_quark ()
 {
-    JSObjectRef global = JSContextGetGlobalObject (ctx);
-    JSValueRef val = uzbl_js_get (ctx, global, prop);
-
-    return JSValueToObject (ctx, val, NULL);
+    return g_quark_from_static_string ("uzbl-js-error-quark");
 }
 
 JSValueRef
@@ -69,4 +129,75 @@ uzbl_js_extract_string (JSStringRef str)
     JSStringGetUTF8CString (str, gstr, max_size);
 
     return gstr;
+}
+
+
+JSObjectRef
+uzbl_js_object (JSContextRef ctx, const gchar *prop)
+{
+    JSObjectRef global = JSContextGetGlobalObject (ctx);
+    JSValueRef val = uzbl_js_get (ctx, global, prop);
+
+    return JSValueToObject (ctx, val, NULL);
+}
+
+gchar *
+uzbl_js_run_string (UzblJSContext context, const gchar *script)
+{
+    gchar *result_utf8 = NULL;
+
+    GError *err = NULL;
+    JSGlobalContextRef jsctx = uzbl_js_get_context (context);
+    JSValueRef result = uzbl_js_evaluate (jsctx, script, "(uzbl command)", &err);
+    if (err != NULL) {
+        g_debug ("Exception occured while executing script: %s", err->message);
+        g_clear_error (&err);
+    }
+    if (result && !JSValueIsUndefined (jsctx, result)) {
+        result_utf8 = uzbl_js_to_string (jsctx, result);
+    }
+
+    JSGlobalContextRelease (jsctx);
+    return result_utf8;
+}
+
+gchar *
+uzbl_js_run_file (UzblJSContext context, const gchar *path, GArray *argv)
+{
+    gchar *script;
+    gchar *result_utf8 = NULL;
+
+    GIOChannel *chan = g_io_channel_new_file (path, "r", NULL);
+    if (chan) {
+        gsize len;
+        g_io_channel_read_to_end (chan, &script, &len, NULL);
+        g_io_channel_unref (chan);
+    }
+
+    uzbl_debug ("External JavaScript file loaded: %s\n", path);
+    guint i;
+    for (i = argv->len; 0 != i; --i) {
+        const gchar *arg = argv_idx (argv, i - 1);
+        gchar *needle = g_strdup_printf ("%%%d", i);
+
+        gchar *new_file_contents = str_replace (needle, arg ? arg : "", script);
+
+        g_free (needle);
+        g_free (script);
+        script = new_file_contents;
+    }
+
+    GError *err = NULL;
+    JSGlobalContextRef jsctx = uzbl_js_get_context (context);
+    JSValueRef result = uzbl_js_evaluate (jsctx, script, path, &err);
+    if (err != NULL) {
+        g_debug ("Exception occured while executing script: %s", err->message);
+        g_clear_error (&err);
+    }
+    if (result && !JSValueIsUndefined (jsctx, result)) {
+        result_utf8 = uzbl_js_to_string (jsctx, result);
+    }
+
+    JSGlobalContextRelease (jsctx);
+    return result_utf8;
 }

--- a/src/js.h
+++ b/src/js.h
@@ -2,6 +2,7 @@
 #define UZBL_JS_H
 
 #include <glib.h>
+#include <gio/gio.h>
 #include <JavaScriptCore/JavaScript.h>
 
 #define UZBL_JS_ERROR uzbl_js_error_quark ()
@@ -42,13 +43,22 @@ JSObjectRef
 uzbl_js_object (JSContextRef  ctx,
                 const gchar  *prop);
 
-gchar *
-uzbl_js_run_string (UzblJSContext  context,
-                    const gchar   *script);
+void
+uzbl_js_run_string_async (UzblJSContext        context,
+                          const gchar         *script,
+                          GAsyncReadyCallback  callback,
+                          gpointer             data);
+
+void
+uzbl_js_run_file_async (UzblJSContext        context,
+                        const gchar         *path,
+                        GArray              *args,
+                        GAsyncReadyCallback  callback,
+                        gpointer             data);
 
 gchar *
-uzbl_js_run_file (UzblJSContext  context,
-                  const gchar   *path,
-                  GArray        *args);
+uzbl_js_run_finish (GObject       *source,
+                    GAsyncResult  *result,
+                    GError       **error);
 
 #endif

--- a/src/js.h
+++ b/src/js.h
@@ -1,19 +1,54 @@
 #ifndef UZBL_JS_H
 #define UZBL_JS_H
 
-#include "webkit.h"
-
+#include <glib.h>
 #include <JavaScriptCore/JavaScript.h>
 
-JSObjectRef
-uzbl_js_object (JSContextRef ctx, const gchar *prop);
+#define UZBL_JS_ERROR uzbl_js_error_quark ()
+
+typedef enum {
+    UZBL_JS_ERROR_EVAL
+} UzblJsError;
+
+typedef enum {
+    JSCTX_UZBL,
+    JSCTX_CLEAN,
+    JSCTX_PAGE
+} UzblJSContext;
+
+GQuark
+uzbl_js_error_quark ();
+
 JSValueRef
-uzbl_js_get (JSContextRef ctx, JSObjectRef obj, const gchar *prop);
+uzbl_js_get (JSContextRef ctx,
+             JSObjectRef  obj,
+             const gchar *prop);
+
 void
-uzbl_js_set (JSContextRef ctx, JSObjectRef obj, const gchar *prop, JSValueRef val, JSPropertyAttributes props);
+uzbl_js_set (JSContextRef          ctx,
+             JSObjectRef           obj,
+             const gchar          *prop,
+             JSValueRef            val,
+             JSPropertyAttributes  props);
+
 gchar *
-uzbl_js_to_string (JSContextRef ctx, JSValueRef obj);
+uzbl_js_to_string (JSContextRef ctx,
+                   JSValueRef   obj);
+
 gchar *
 uzbl_js_extract_string (JSStringRef str);
+
+JSObjectRef
+uzbl_js_object (JSContextRef  ctx,
+                const gchar  *prop);
+
+gchar *
+uzbl_js_run_string (UzblJSContext  context,
+                    const gchar   *script);
+
+gchar *
+uzbl_js_run_file (UzblJSContext  context,
+                  const gchar   *path,
+                  GArray        *args);
 
 #endif

--- a/src/util.c
+++ b/src/util.c
@@ -10,6 +10,12 @@
 
 /* =========================== PUBLIC API =========================== */
 
+GQuark
+uzbl_arg_error_quark ()
+{
+    return g_quark_from_static_string ("uzbl-arg-error-quark");
+}
+
 gchar *
 argv_idx (const GArray *argv, guint idx)
 {

--- a/src/util.c
+++ b/src/util.c
@@ -42,6 +42,12 @@ remove_trailing_newline (const char *line)
     }
 }
 
+void
+free_gstring (gpointer data)
+{
+    g_string_free ((GString*)data, TRUE);
+}
+
 gboolean
 file_exists (const char *filename)
 {

--- a/src/util.h
+++ b/src/util.h
@@ -19,6 +19,9 @@ str_replace (const gchar *needle, const gchar *replace, const gchar *haystack);
 void
 remove_trailing_newline (const char *line);
 
+void
+free_gstring(gpointer data);
+
 gboolean
 file_exists (const char *filename);
 /* Search a PATH style string for an existing file+path combination. everything

--- a/src/util.h
+++ b/src/util.h
@@ -2,6 +2,12 @@
 
 #define UZBL_UNUSED(var) (void)var
 
+#define UZBL_ARG_ERROR uzbl_arg_error_quark ()
+
+typedef enum {
+    UZBL_ARG_ERROR_ARGUMENT
+} UzblArgError;
+
 #define ARG_CHECK(argv, count)   \
     do                           \
     {                            \
@@ -9,6 +15,25 @@
             return;              \
         }                        \
     } while (false)
+
+#define TASK_ARG_CHECK(task, argv, count)                        \
+    do                                                           \
+    {                                                            \
+        if (argv->len < count) {                                 \
+            g_task_return_new_error (                            \
+                task,                                            \
+                UZBL_ARG_ERROR,                                  \
+                UZBL_ARG_ERROR_ARGUMENT,                         \
+                "not enough arguments (expected %d, was %d)",    \
+                count,                                           \
+                argv->len                                        \
+            );                                                   \
+            return;                                              \
+        }                                                        \
+    } while (false)
+
+GQuark
+uzbl_arg_error_quark ();
 
 gchar *
 argv_idx (const GArray *argv, guint idx);


### PR DESCRIPTION
Still some work left to but mostly minor stuff I hope. But the exciting stuff is that it's now possible to run javascript commands in the page again

```
$ socat - /var/run/user/1000/uzbl/uzbl_socket_1858 
js page string '1+1'
2
js page string '""+window.location'
about:blank
```

For some weird reason webkit chokes on the 2nd if trying to use `window.location` bare

- [x] Find the best place to create the GString (up front and carry or in done?)
- [x] Reduce boilerplate for tasks (give initialised GTask as argument?)
- [ ] Fix COMMAND_EXECUTED event