### PR TITLE
Use a pre-baked docker image

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,7 @@ matrix:
 install:
     - pip install six nose mock coveralls
     - python -c 'import configparser' || pip install configparser
-    - if test -n "$CORETESTS"; then docker build -t uzbl-build misc/; fi
 script:
-    - if test -n "$CORETESTS"; then docker run -v $(pwd):/uzbl -w /uzbl uzbl-build make tests; else nosetests tests/event-manager --with-coverage --cover-package=uzbl; fi
+    - if test -n "$CORETESTS"; then docker run -v $(pwd):/uzbl -w /uzbl dkeis/debian-webkit2 make tests; else nosetests tests/event-manager --with-coverage --cover-package=uzbl; fi
 after_success:
     coveralls


### PR DESCRIPTION
Should make the tests less flaky and hopefully faster

split the docker build to here https://github.com/uzbl/debian-webkit2