### PR TITLE
Async expand

### DIFF
--- a/src/commands.c
+++ b/src/commands.c
@@ -190,6 +190,12 @@ static const UzblCommand *
 parse_command (const gchar *exp_line, GArray *argv);
 
 const UzblCommand *
+uzbl_commands_lookup (const gchar *cmd)
+{
+    return g_hash_table_lookup (uzbl.commands->table, cmd);
+}
+
+const UzblCommand *
 uzbl_commands_parse (const gchar *cmd, GArray *argv)
 {
     if (!cmd || cmd[0] == '#' || !*cmd) {
@@ -260,7 +266,7 @@ parse_command (const gchar *exp_line, GArray *argv)
     const gchar *arg_string = tokens[1];
 
     /* Look up the command. */
-    const UzblCommand *info = g_hash_table_lookup (uzbl.commands->table, command);
+    const UzblCommand *info = uzbl_commands_lookup (command);
 
     if (!info) {
         uzbl_events_send (COMMAND_ERROR, NULL,
@@ -450,7 +456,7 @@ void
 uzbl_commands_run_argv (const gchar *cmd, GArray *argv, GString *result)
 {
     /* Look up the command. */
-    const UzblCommand *info = g_hash_table_lookup (uzbl.commands->table, cmd);
+    const UzblCommand *info = uzbl_commands_lookup (cmd);
 
     if (!info) {
         uzbl_events_send (COMMAND_ERROR, NULL,

--- a/src/commands.c
+++ b/src/commands.c
@@ -61,7 +61,7 @@ typedef struct _UzblCommandRun UzblCommandRun;
 struct _UzblCommandRun {
     const UzblCommand *info;
     const GArray      *argv;
-    GString     *result;
+    GString           *result;
 };
 
 #if WEBKIT_CHECK_VERSION (2, 5, 1)
@@ -223,6 +223,28 @@ uzbl_commands_parse (const gchar *cmd, GArray *argv)
     g_strfreev (tokens);
 
     return info;
+}
+
+void
+uzbl_commands_parse_async (const gchar         *cmd,
+                           GArray              *argv,
+                           GAsyncReadyCallback  callback,
+                           gpointer             data)
+{
+    GTask *task = g_task_new (NULL, NULL, callback, data);
+    const UzblCommand *info = uzbl_commands_parse (cmd, argv);
+    g_task_return_pointer (task, (UzblCommand*)info, NULL);
+    g_object_unref (task);
+}
+
+const UzblCommand*
+uzbl_command_parse_finish (GObject       *source,
+                           GAsyncResult  *res,
+                           GError       **error)
+{
+    UZBL_UNUSED (source);
+    GTask *task = G_TASK (res);
+    return g_task_propagate_pointer (task, error);
 }
 
 void

--- a/src/commands.h
+++ b/src/commands.h
@@ -22,11 +22,16 @@ uzbl_commands_parse_async (const gchar         *cmd,
                            GAsyncReadyCallback  callback,
                            gpointer             data);
 const UzblCommand *
-uzbl_command_parse_finish (GObject       *source,
-                           GAsyncResult  *res,
-                           GError       **error);
+uzbl_commands_parse_finish (GObject       *source,
+                            GAsyncResult  *res,
+                            GError       **error);
 void
 uzbl_commands_run_parsed (const UzblCommand *info, GArray *argv, GString *result);
+void
+uzbl_commands_run_string_async (const gchar         *cmd,
+                                gboolean             capture,
+                                GAsyncReadyCallback  callback,
+                                gpointer             data);
 void
 uzbl_commands_run_async (const UzblCommand   *info,
                          GArray              *argv,

--- a/src/commands.h
+++ b/src/commands.h
@@ -17,6 +17,15 @@ uzbl_commands_args_free (GArray *argv);
 const UzblCommand *
 uzbl_commands_parse (const gchar *cmd, GArray *argv);
 void
+uzbl_commands_parse_async (const gchar         *cmd,
+                           GArray              *argv,
+                           GAsyncReadyCallback  callback,
+                           gpointer             data);
+const UzblCommand *
+uzbl_command_parse_finish (GObject       *source,
+                           GAsyncResult  *res,
+                           GError       **error);
+void
 uzbl_commands_run_parsed (const UzblCommand *info, GArray *argv, GString *result);
 void
 uzbl_commands_run_async (const UzblCommand   *info,

--- a/src/commands.h
+++ b/src/commands.h
@@ -4,6 +4,15 @@
 #include <glib.h>
 #include <gio/gio.h>
 
+#define UZBL_COMMAND_ERROR uzbl_command_error_quark ()
+
+typedef enum {
+    UZBL_COMMAND_ERROR_INVALID_COMMAND
+} UzblCommandError;
+
+GQuark
+uzbl_command_error_quark ();
+
 struct _UzblCommand;
 typedef struct _UzblCommand UzblCommand;
 

--- a/src/commands.h
+++ b/src/commands.h
@@ -15,6 +15,9 @@ void
 uzbl_commands_args_free (GArray *argv);
 
 const UzblCommand *
+uzbl_commands_lookup (const gchar *cmd);
+
+const UzblCommand *
 uzbl_commands_parse (const gchar *cmd, GArray *argv);
 void
 uzbl_commands_parse_async (const gchar         *cmd,

--- a/src/io.c
+++ b/src/io.c
@@ -534,17 +534,11 @@ run_command_async (GTask *cmdt, GAsyncReadyCallback callback, gpointer data)
     GTask *task = g_task_new (cmdt, NULL, callback, data);
     UzblCommandData *cmd = (UzblCommandData*) g_task_get_task_data (cmdt);
 
-    const UzblCommand *info;
-    GArray *argv;
     if (cmd->cmd) {
-        argv = cmd->argv = uzbl_commands_args_new ();
-        info = uzbl_commands_parse (cmd->cmd, argv);
+        uzbl_commands_run_string_async (cmd->cmd, TRUE, commands_run_cb, task);
     } else {
-        argv = cmd->argv;
-        info = cmd->info;
+        uzbl_commands_run_async (cmd->info, cmd->argv, TRUE, commands_run_cb, task);
     }
-
-    uzbl_commands_run_async (info, argv, TRUE, commands_run_cb, task);
 }
 
 void

--- a/src/variables.c
+++ b/src/variables.c
@@ -382,6 +382,27 @@ uzbl_variables_expand (const gchar *str)
     return expand_impl (str, EXPAND_INITIAL);
 }
 
+void
+uzbl_variables_expand_async (const gchar         *str,
+                             GAsyncReadyCallback  callback,
+                             gpointer             data)
+{
+    GTask *task = g_task_new (NULL, NULL, callback, data);
+    gchar *result = expand_impl (str, EXPAND_INITIAL);
+    g_task_return_pointer (task, result, NULL);
+    g_object_unref (task);
+}
+
+gchar*
+uzbl_variables_expand_finish (GObject       *source,
+                              GAsyncResult  *res,
+                              GError       **error)
+{
+    UZBL_UNUSED (source);
+    GTask *task = G_TASK (res);
+    return g_task_propagate_pointer (task, error);
+}
+
 #define VAR_GETTER(type, name)                     \
     type                                           \
     uzbl_variables_get_##name (const gchar *name_) \

--- a/src/variables.h
+++ b/src/variables.h
@@ -2,6 +2,7 @@
 #define UZBL_VARIABLES_H
 
 #include <glib.h>
+#include <gio/gio.h>
 
 gboolean
 uzbl_variables_is_valid (const gchar *name);
@@ -13,6 +14,14 @@ uzbl_variables_toggle (const gchar *name, GArray *values);
 
 gchar *
 uzbl_variables_expand (const gchar *str);
+void
+uzbl_variables_expand_async (const gchar         *str,
+                             GAsyncReadyCallback  callback,
+                             gpointer             data);
+gchar*
+uzbl_variables_expand_finish (GObject       *source,
+                              GAsyncResult  *res,
+                              GError       **error);
 
 gchar *
 uzbl_variables_get_string (const gchar *name);


### PR DESCRIPTION
With this patch JS expansions work again. However only when using the `uzbl_commands_run_async` variant.

As per #307 I want to use these methods as much as possible before it can really by considered done but this should at least get the basic key bindings working again.
