### PR TITLE
Fix double character from split_quoted

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,21 +6,16 @@ python:
     - "3.4"
     - "3.5"
     - "pypy"
+services:
+    - docker
 matrix:
   include:
     - python: "3.5"
       env: CORETESTS=1
-addons:
-  apt:
-    sources:
-      - debian-sid
-    packages:
-      - libglib2.0-dev
-      - libwebkitgtk-dev
 install:
     - pip install six nose mock coveralls
     - python -c 'import configparser' || pip install configparser
 script:
-    - if test -n "$CORETESTS"; then make tests; else nosetests tests/event-manager --with-coverage --cover-package=uzbl; fi
+    - if test -n "$CORETESTS"; then docker run -v $(pwd):/uzbl -w /uzbl dkeis/debian-webkit2 make tests; else nosetests tests/event-manager --with-coverage --cover-package=uzbl; fi
 after_success:
     coveralls

--- a/src/commands.c
+++ b/src/commands.c
@@ -479,6 +479,7 @@ split_quoted (const gchar *src)
         if ((*p == '\\') && p[1]) {
             /* Escaped character. */
             g_string_append_c (str, *++p);
+            ++p;
         } else if ((*p == '"') && !ctx_single_quote) {
             /* Double quoted argument. */
             ctx_double_quote = !ctx_double_quote;

--- a/tests/core-tests.c
+++ b/tests/core-tests.c
@@ -44,6 +44,17 @@ test_parse_extra_whitespace ()
     g_assert_cmpstr (g_array_index (argv, gchar*, 2), ==, "baz");
 }
 
+static void
+test_parse_escaped_at ()
+{
+    GArray *argv = uzbl_commands_args_new ();
+    const UzblCommand *cmd = uzbl_commands_parse ("spawn \\@", argv);
+
+    g_assert_nonnull (cmd);
+    g_assert_cmpint (1, ==, argv->len);
+    g_assert_cmpstr (g_array_index (argv, gchar*, 0), ==, "@");
+}
+
 int
 main (int argc, char *argv[])
 {
@@ -54,6 +65,7 @@ main (int argc, char *argv[])
     g_test_add_func ("/uzbl/commands/parse_simple", test_parse_simple);
     g_test_add_func ("/uzbl/commands/parse_quoted", test_parse_quoted);
     g_test_add_func ("/uzbl/commands/parse_extra_whitespace", test_parse_extra_whitespace);
+    g_test_add_func ("/uzbl/commands/parse_escaped_at", test_parse_escaped_at);
 
     return g_test_run ();
 }


### PR DESCRIPTION
Previously escaped characters would be repeated and the bindings using
sed to escape `@` would fail because it would instead search for `@@`