### PR TITLE
uzbl-browser: prefer XDG_RUNTIME_DIR to XDG_CACHE_HOME

### DIFF
--- a/bin/uzbl-browser.in
+++ b/bin/uzbl-browser.in
@@ -61,7 +61,13 @@ fi
 # uzbl-event-manager will exit if one is already running.
 # we could also check if its pid file exists to avoid having to spawn it.
 if [ -z "$UZBL_EVENT_SOCKET" ]; then
-	UZBL_EVENT_SOCKET="$XDG_CACHE_HOME/uzbl/event_daemon"
+	if [ -z "$XDG_RUNTIME_DIR" ]; then
+		UZBL_EVENT_SOCKET_DIR="$XDG_CACHE_HOME/uzbl"
+	else
+		UZBL_EVENT_SOCKET_DIR="$XDG_RUNTIME_DIR/uzbl"
+	fi
+	mkdir -p "$UZBL_EVENT_SOCKET_DIR"
+	UZBL_EVENT_SOCKET="$UZBL_EVENT_SOCKET_DIR/event_daemon"
 	if ! [ -f "$UZBL_EVENT_SOCKET.pid" ] || ! ps -p "$(cat "$UZBL_EVENT_SOCKET.pid")" >/dev/null; then
 		${UZBL_EVENT_MANAGER:-uzbl-event-manager -va --server-socket "$UZBL_EVENT_SOCKET" start} || \
 			die_with_status 4 "Error: Could not start uzbl-event-manager"

--- a/uzbl/event_manager.py
+++ b/uzbl/event_manager.py
@@ -62,6 +62,10 @@ def xdghome(key, default):
 DATA_DIR = os.path.join(xdghome('DATA', '.local/share/'), 'uzbl/')
 CACHE_DIR = os.path.join(xdghome('CACHE', '.cache/'), 'uzbl/')
 CONFIG_DIR = os.path.join(xdghome('CONFIG', '.config/'), 'uzbl/')
+if 'XDG_RUNTIME_DIR' in os.environ:
+    RUNTIME_DIR = os.path.join(os.environ['XDG_RUNTIME_DIR'], 'uzbl/')
+else:
+    RUNTIME_DIR = None
 
 # Define some globals.
 SCRIPTNAME = os.path.basename(sys.argv[0])
@@ -340,7 +344,10 @@ def make_parser():
         dest='config', metavar='CONFIG', default=config_location,
         help='configuration file')
 
-    socket_location = os.path.join(CACHE_DIR, 'event_daemon')
+    if RUNTIME_DIR:
+        socket_location = os.path.join(RUNTIME_DIR, 'event_daemon')
+    else:
+        socket_location = os.path.join(CACHE_DIR, 'event_daemon')
 
     add('-s', '--server-socket',
         dest='server_socket', metavar="SOCKET", default=socket_location,


### PR DESCRIPTION
Sockets are ephemeral, not something to be cached.

Fixes #336.