### PR TITLE
Build event-manager python wheel

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,10 @@
+import os
 from setuptools import setup
 
+VERSION = os.getenv('VERSION', '0+devel')
+
 setup(name='uzbl',
-      version='201100808',
+      version=VERSION,
       description='Uzbl event daemon',
       url='http://uzbl.org',
       packages=['uzbl', 'uzbl.plugins'],


### PR DESCRIPTION
Build a wheel from the uzbl python package during `make` with version
information pulled from `misc/hash.sh`. This is later installed using
pip which avoids touching the dist directory as root.