### PR TITLE
extio: initialize GError with `NULL`

### DIFF
--- a/src/extio.c
+++ b/src/extio.c
@@ -53,7 +53,7 @@ read_header_read_all_cb (GObject      *source,
     GInputStream *stream = G_INPUT_STREAM (source);
     GTask *task = G_TASK (user_data);
     gsize read;
-    GError *error;
+    GError *error = NULL;
     void *buffer = g_task_get_task_data (task);
 
     if (!g_input_stream_read_all_finish (stream, res, &read, &error)) {


### PR DESCRIPTION
Glib/GIO functions expect the error out parameters to be initialized to
`NULL`, but we fail to initialize it in `read_header_read_all_cb`. This
can actually cause undefined behavior and segfaults when executed, as is
observed for example when starting up `uzbl-core` with the uzbl
webextension.

Fix the error by initializing the variable to `NULL`.