### PR TITLE
gui: fix detection of click target

### DIFF
--- a/src/gui.c
+++ b/src/gui.c
@@ -40,6 +40,7 @@ struct _UzblGui {
     guint current_key_state;
 
     GdkEventButton *last_button;
+    WebKitHitTestResultContext last_hit_context;
 
     gboolean load_failed;
 #if WEBKIT_CHECK_VERSION (2, 5, 1)
@@ -696,14 +697,12 @@ mouse_target_cb (WebKitWebView *view, WebKitHitTestResult *hit_test, guint modif
 
     /* TODO: Do something with modifiers? */
 
-    WebKitHitTestResultContext context;
-
     g_object_get (G_OBJECT (hit_test),
-        "context", &context,
+        "context", &uzbl.gui_->last_hit_context,
         NULL);
 
     /* TODO: Handle other cases? */
-    if (!(context & WEBKIT_HIT_TEST_RESULT_CONTEXT_LINK)) {
+    if (!(uzbl.gui_->last_hit_context & WEBKIT_HIT_TEST_RESULT_CONTEXT_LINK)) {
         send_hover_event ("", "");
         return;
     }
@@ -1637,7 +1636,7 @@ send_keypress_event (GdkEventKey *event)
 gint
 get_click_context ()
 {
-    guint context = NO_CLICK_CONTEXT;
+    guint context = uzbl.gui_->last_hit_context;
 
     if (!uzbl.gui_->last_button) {
         return NO_CLICK_CONTEXT;


### PR DESCRIPTION
When performing a click inside of the WebView, we notify event handlers
whether a form or the root document is active. We do so by retrieving
inspecting the hit test result context, which includes a bit mask of
what has been hit by the click. The hit test result context is retrieved
via the function `get_click_context`. But upon further inspection, this
function will always return `NO_CLICK_CONTEXT`, breaking our ability to
distinguish between clicks on a form and the root document.

The WebKitHitTestResult can be acquired by listening on the
"mouse-target-changed" event. While we do so already, we do not store
the bitmask anywhere and as such, it is not available when
`get_click_context` is called.

We fix this by introducing a new field `last_hit_context` to the
`_UzblGui` structure, which is then subsequently used in
`get_click_context` to return the actual context. This fixes detection
of clicks on the document root.