### PR TITLE
Bring back scrolling

### DIFF
--- a/src/extio.c
+++ b/src/extio.c
@@ -58,6 +58,7 @@ read_header_read_all_cb (GObject      *source,
 
     if (!g_input_stream_read_all_finish (stream, res, &read, &error)) {
         g_task_return_error (task, error);
+        g_object_unref (task);
         return;
     }
 
@@ -66,6 +67,7 @@ read_header_read_all_cb (GObject      *source,
                                              NULL, NULL);
 
     g_task_return_pointer (task, var, NULL);
+    g_object_unref (task);
 }
 
 GVariant*
@@ -134,6 +136,7 @@ read_payload_read_all_cb (GObject      *source,
 
     if (!g_input_stream_read_all_finish (stream, res, &read, &error)) {
         g_task_return_error (task, error);
+        g_object_unref (task);
         return;
     }
 
@@ -141,6 +144,7 @@ read_payload_read_all_cb (GObject      *source,
     GVariant *var = g_variant_new_from_data (type, data->buffer, read, FALSE,
                                              NULL, NULL);
     g_task_return_pointer (task, var, NULL);
+    g_object_unref (task);
 }
 
 GVariant*
@@ -190,6 +194,7 @@ read_header_cb (GObject      *source,
 
     if (!(header = read_header_finish (stream, res, &error))) {
         g_task_return_error (task, error);
+        g_object_unref (task);
         return;
     }
 
@@ -214,11 +219,13 @@ read_payload_cb (GObject     *source,
 
     if (!(var = read_payload_finish (stream, res, &messagetype, &error))) {
         g_task_return_error (task, error);
+        g_object_unref (task);
         return;
     }
 
     g_task_set_task_data (task, GINT_TO_POINTER (messagetype), NULL);
     g_task_return_pointer (task, var, g_free);
+    g_object_unref (task);
 }
 
 GVariant *

--- a/src/extio.c
+++ b/src/extio.c
@@ -250,6 +250,8 @@ uzbl_extio_get_variant_type (ExtIOMessageType type)
     case EXT_FOCUS:
     case EXT_BLUR:
         return G_VARIANT_TYPE ("s");
+    case EXT_SCROLL:
+        return G_VARIANT_TYPE ("(yyyi)");
     }
 
     return 0;

--- a/src/extio.c
+++ b/src/extio.c
@@ -260,13 +260,24 @@ uzbl_extio_send_message (GOutputStream    *stream,
     gchar *buf = g_malloc (headersize);
     g_variant_store (header, buf);
 
-    g_output_stream_write (stream, buf, headersize, NULL, NULL);
+    GError *err = NULL;
+    g_output_stream_write (stream, buf, headersize, NULL, &err);
+    if (err) {
+        g_warning ("Error writing message header: %s", err->message);
+        g_error_free (err);
+        return;
+    }
     g_variant_unref (header);
     g_free (buf);
 
     buf = g_malloc (size);
     g_variant_store (message, buf);
-    g_output_stream_write (stream, buf, size, NULL, NULL);
+    g_output_stream_write (stream, buf, size, NULL, &err);
+    if (err) {
+        g_warning ("Error writing message data: %s", err->message);
+        g_error_free (err);
+        return;
+    }
 }
 
 void

--- a/src/extio.h
+++ b/src/extio.h
@@ -9,8 +9,26 @@
 typedef enum {
     EXT_HELO,
     EXT_FOCUS,
-    EXT_BLUR
+    EXT_BLUR,
+    EXT_SCROLL,
 } ExtIOMessageType;
+
+typedef enum {
+    SCROLL_HORIZONTAL,
+    SCROLL_VERTICAL,
+} ScrollAxis;
+
+typedef enum {
+    SCROLL_SET,
+    SCROLL_TRANSLATE,
+    SCROLL_BEGIN,
+    SCROLL_END,
+} ScrollAction;
+
+typedef enum {
+    SCROLL_FIXED,
+    SCROLL_PERCENTAGE,
+} ScrollMode;
 
 void
 uzbl_extio_read_message_async (GInputStream        *stream,

--- a/src/gui.c
+++ b/src/gui.c
@@ -296,7 +296,6 @@ initialize_web_extensions (WebKitWebContext *context, gpointer user_data)
     int in;
     int out;
 
-    uzbl_io_init_extpipe ();
     uzbl_io_extfds (&in, &out);
 
     GVariant *data = g_variant_new ("(ixx)", EXTIO_PROTOCOL, in, out);

--- a/src/uzbl-core.c
+++ b/src/uzbl-core.c
@@ -242,6 +242,7 @@ uzbl_init (int *argc, char ***argv)
     uzbl_requests_init ();
 
     /* Initialize the GUI. */
+    uzbl_io_init_extpipe ();
     uzbl_gui_init (cache_dir, data_dir, uzbl.state.web_extensions_directory);
     uzbl_inspector_init ();
 

--- a/src/uzbl-ext.c
+++ b/src/uzbl-ext.c
@@ -222,7 +222,9 @@ ext_scroll_web_page (UzblExt      *ext,
         if (mode == SCROLL_PERCENTAGE) {
             glong page = (axis == SCROLL_HORIZONTAL) ? webkit_dom_element_get_scroll_width (body)
                                                      : webkit_dom_element_get_scroll_height (body);
-            amount = (gint32) page * amount * 0.01;
+            glong screen = (axis == SCROLL_HORIZONTAL) ? webkit_dom_dom_window_get_inner_width (win)
+                                                       : webkit_dom_dom_window_get_inner_height (win);
+            amount = (gint32) (page - screen) * amount * 0.01;
         }
 
         webkit_dom_dom_window_scroll_to (

--- a/src/uzbl-ext.c
+++ b/src/uzbl-ext.c
@@ -6,18 +6,31 @@
 #include "extio.h"
 #include "util.h"
 
+// The unstable API is generated from the DOM specs and things might break
+// between versions, especially if using new and experimental features.
+#define WEBKIT_DOM_USE_UNSTABLE_API
+#include <webkitdom/WebKitDOMDOMWindowUnstable.h>
+
 struct _UzblExt {
-    GIOStream *stream;
+    GIOStream     *stream;
+    WebKitWebPage *web_page;
 };
 
 UzblExt*
 uzbl_ext_new ()
 {
-    UzblExt *ext = g_new (UzblExt, 1);
+    UzblExt *ext = g_new0 (UzblExt, 1);
     return ext;
 }
 
-void
+static void
+ext_scroll_web_page (UzblExt      *ext,
+                     ScrollAxis    axis,
+                     ScrollAction  action,
+                     ScrollMode    mode,
+                     gint32        amount);
+
+static void
 read_message_cb (GObject *stream,
                  GAsyncResult *res,
                  gpointer user_data);
@@ -51,6 +64,15 @@ read_message_cb (GObject *source,
     }
 
     switch (messagetype) {
+    case EXT_SCROLL:
+        {
+            gchar axis, action, mode;
+            guint32 amount;
+            uzbl_extio_get_message_data (EXT_SCROLL, message,
+                &axis, &action, &mode, &amount);
+            ext_scroll_web_page (ext, axis, action, mode, amount);
+            break;
+        }
     default:
         {
             gchar *pmsg = g_variant_print (message, TRUE);
@@ -120,7 +142,7 @@ web_page_created_callback (WebKitWebExtension *extension,
     UzblExt *ext = (UzblExt*)user_data;
 
     g_debug ("Web page created");
-
+    ext->web_page = web_page;
     g_signal_connect (web_page, "document-loaded",
                       G_CALLBACK (document_loaded_callback), ext);
 }
@@ -166,4 +188,61 @@ dom_blur_callback (WebKitDOMEventTarget *target,
 
     uzbl_extio_send_new_message (g_io_stream_get_output_stream (ext->stream),
                                  EXT_BLUR, name);
+}
+
+void
+ext_scroll_web_page (UzblExt      *ext,
+                     ScrollAxis    axis,
+                     ScrollAction  action,
+                     ScrollMode    mode,
+                     gint32        amount)
+{
+    WebKitDOMDocument *doc = webkit_web_page_get_dom_document (ext->web_page);
+    WebKitDOMDOMWindow *win = webkit_dom_document_get_default_view (doc);
+    WebKitDOMElement *body = WEBKIT_DOM_ELEMENT (
+        webkit_dom_document_get_body (doc));
+
+    if (action == SCROLL_BEGIN) {
+        webkit_dom_dom_window_scroll_to (
+            win,
+            axis == SCROLL_HORIZONTAL ? 0
+                                      : webkit_dom_dom_window_get_scroll_x (win),
+            axis == SCROLL_HORIZONTAL ? webkit_dom_dom_window_get_scroll_y (win)
+                                      : 0
+        );
+    } else if (action == SCROLL_END) {
+        webkit_dom_dom_window_scroll_to (
+            win,
+            axis == SCROLL_HORIZONTAL ? webkit_dom_element_get_scroll_width (body)
+                                      : webkit_dom_dom_window_get_scroll_x (win),
+            axis == SCROLL_HORIZONTAL ? webkit_dom_dom_window_get_scroll_y (win)
+                                      : webkit_dom_element_get_scroll_height (body)
+        );
+    } else if (action == SCROLL_SET) {
+        if (mode == SCROLL_PERCENTAGE) {
+            glong page = (axis == SCROLL_HORIZONTAL) ? webkit_dom_element_get_scroll_width (body)
+                                                     : webkit_dom_element_get_scroll_height (body);
+            amount = (gint32) page * amount * 0.01;
+        }
+
+        webkit_dom_dom_window_scroll_to (
+            win,
+            axis == SCROLL_HORIZONTAL ? amount
+                                      : webkit_dom_dom_window_get_scroll_x (win),
+            axis == SCROLL_HORIZONTAL ? webkit_dom_dom_window_get_scroll_y (win)
+                                      : amount
+        );
+    } else if (action == SCROLL_TRANSLATE) {
+        if (mode == SCROLL_PERCENTAGE) {
+            glong screen = (axis == SCROLL_HORIZONTAL) ? webkit_dom_dom_window_get_inner_width (win)
+                                                       : webkit_dom_dom_window_get_inner_height (win);
+            amount = (gint32) screen * amount * 0.01;
+        }
+
+        webkit_dom_dom_window_scroll_by (
+            win,
+            axis == SCROLL_HORIZONTAL ? amount : 0,
+            axis == SCROLL_HORIZONTAL ? 0 : amount
+        );
+    }
 }


### PR DESCRIPTION
Implement scroll command using web extension

Introduces a new extension message EXT_SCROLL that can scroll the
current web view. It makes use of the webkit DOM api bindings and will
either use scroll_by or scroll_to depending on the requested action.

Fixes #323