### PR TITLE
Set default useragent in core

### DIFF
--- a/examples/config/config
+++ b/examples/config/config
@@ -143,10 +143,6 @@ set progress.format     [%d>%p]%c
 set progress.done       =
 set progress.pending
 
-# === Useragent setup ========================================================
-
-set useragent Mozilla/5.0 (X11; @(+uname -sm)@) AppleWebKit/602.1 (KHTML; like Gecko) Uzbl/@COMMIT
-
 # === Configure cookie blacklist =============================================
 
 set cookie_policy always

--- a/src/gui.c
+++ b/src/gui.c
@@ -379,11 +379,15 @@ web_view_init (WebKitWebContext *context)
 #if WEBKIT_CHECK_VERSION (2, 5, 1)
     uzbl.gui_->user_manager = webkit_user_content_manager_new ();
 #endif
+    WebKitSettings *settings = webkit_settings_new ();
+    webkit_settings_set_user_agent_with_application_details (
+        settings, "Uzbl", COMMIT);
     uzbl.gui.web_view = WEBKIT_WEB_VIEW (g_object_new (WEBKIT_TYPE_WEB_VIEW,
         "web-context", context,
 #if WEBKIT_CHECK_VERSION (2, 5, 1)
         "user-content-manager", uzbl.gui_->user_manager,
 #endif
+        "settings", settings,
         NULL));
     uzbl.gui.scrolled_win = gtk_scrolled_window_new (NULL, NULL);
 


### PR DESCRIPTION
Results in a UA like this `Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/602.1 (KHTML; like Gecko) Uzbl/v0.9.1-170-g7a72bfe` and can still be change with `set useragent` as before.

Ref #184 