### PR TITLE
Scroll event

### DIFF
--- a/README.md
+++ b/README.md
@@ -1316,12 +1316,12 @@ uzbl itself and will be emitted based on what is happening within uzbl-core.
   - Sent when a form element has gained focus because of a mouse click.
 * `ROOT_ACTIVE <BUTTON>`
   - Sent when the background page has been clicked.
-* `SCROLL_HORIZ <VALUE> <MIN> <MAX> <PAGE>`
-  - Sent when the page horizontal scroll bar changes. The min and max values
-    are the bounds for scrolling, page is the size that fits in the viewport
-    and the value is the current position of the scrollbar.
-* `SCROLL_VERT <VALUE> <MIN> <MAX> <PAGE>`
-  - Similar to `SCROLL_HORIZ`, but for the vertical scrollbar.
+* `VIEWPORT <LEFT> <TOP> <PAGE_WIDTH> <PAGE_HEIGHT> <WIDTH> <HEIGHT>`
+  - Sent when what part of the page is visible changes in some way, either
+    through scrolling or by resizing the window. The page measures is the total
+    size of the page, width and height indicate the size of the view onto the
+    page, and left and top is the distance of the view from the upper-left
+    corner.
 * `TITLE_CHANGED <TITLE>`
   - Sent when the page title changes.
 * `WEB_PROCESS_CRASHED`

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -333,3 +333,10 @@ for these events. Also check the event manager for built-in handlers.
   - *Change*: Removed `=` argument.
   - *Rationale*: Matches the `set` command.
   - *Porting*: Remove the `=` argument to the event.
+* `SCROLL_VERT`
+  - Replaced by the VIEWPORT event
+  - The Scroll arguments (`VALUE`, `MAX`, `PAGE`) is now found as
+  - `LEFT`, `PAGE_HEIGHT`, `HEIGHT`
+  - `MIN` can be treated as always 0
+* `SCROLL_HORIZ`
+  - Same as `SCROLL_VERT` but with the horizontal components.

--- a/examples/config/config
+++ b/examples/config/config
@@ -97,7 +97,7 @@ set download_handler       spawn_sync @scripts_dir/download.sh
 #@on_event  CONFIG_CHANGED print Config changed: %1 = %2
 
 # Scroll percentage calculation
-@on_event   SCROLL_VERT    set scroll_message \@<(function(curr, min, max, size){if(max == size) return '--'; var p=(curr/(max - size)); return Math.round(10000*p)/100;})(%1,%2,%3,%4)>\@%
+@on_event   VIEWPORT       set scroll_message \@<(function(curr, min, max, size){if(max == size) return '--'; var p=(curr/(max - size)); return Math.round(10000*p)/100;})(%2,0,%4,%6)>\@%
 
 # === Behaviour and appearance ===============================================
 

--- a/examples/config/config
+++ b/examples/config/config
@@ -97,7 +97,7 @@ set download_handler       spawn_sync @scripts_dir/download.sh
 #@on_event  CONFIG_CHANGED print Config changed: %1 = %2
 
 # Scroll percentage calculation
-@on_event   VIEWPORT       set scroll_message \@<(function(curr, min, max, size){if(max == size) return '--'; var p=(curr/(max - size)); return Math.round(10000*p)/100;})(%2,0,%4,%6)>\@%
+@on_event   VIEWPORT       set scroll_message \@<(function(curr, max, size){if(max == size) return '--'; var p=(curr/(max - size)); return Math.round(10000*p)/100;})(%2,%4,%6)>\@%
 
 # === Behaviour and appearance ===============================================
 

--- a/src/events.h
+++ b/src/events.h
@@ -39,8 +39,7 @@
     call (PLUG_CREATED),        \
     call (COMMAND_ERROR),       \
     call (BUILTINS),            \
-    call (SCROLL_VERT),         \
-    call (SCROLL_HORIZ),        \
+    call (VIEWPORT),            \
     call (DOWNLOAD_STARTED),    \
     call (DOWNLOAD_PROGRESS),   \
     call (DOWNLOAD_ERROR),      \

--- a/src/extio.c
+++ b/src/extio.c
@@ -252,6 +252,8 @@ uzbl_extio_get_variant_type (ExtIOMessageType type)
         return G_VARIANT_TYPE ("s");
     case EXT_SCROLL:
         return G_VARIANT_TYPE ("(yyyi)");
+    case EXT_VIEWPORT:
+        return G_VARIANT_TYPE ("(xxxxxx)");
     }
 
     return 0;

--- a/src/extio.h
+++ b/src/extio.h
@@ -11,6 +11,7 @@ typedef enum {
     EXT_FOCUS,
     EXT_BLUR,
     EXT_SCROLL,
+    EXT_VIEWPORT,
 } ExtIOMessageType;
 
 typedef enum {

--- a/src/io.c
+++ b/src/io.c
@@ -898,8 +898,14 @@ read_message_cb (GObject *source,
             uzbl_extio_get_message_data (
                 EXT_VIEWPORT, message,
                 &left, &top, &width, &height, &page_width, &page_height);
-            g_debug ("viewport changed %ld %ld %ld %ld %ld %ld",
-                     left, top, width, height, page_width, page_height);
+            uzbl_events_send (VIEWPORT, NULL,
+                              TYPE_INT, left,
+                              TYPE_INT, top,
+                              TYPE_INT, page_width,
+                              TYPE_INT, page_height,
+                              TYPE_INT, width,
+                              TYPE_INT, height,
+                              NULL);
             break;
         }
     default:

--- a/src/io.c
+++ b/src/io.c
@@ -892,6 +892,16 @@ read_message_cb (GObject *source,
             g_free (name);
             break;
         }
+    case EXT_VIEWPORT:
+        {
+            glong left, top, width, height, page_width, page_height;
+            uzbl_extio_get_message_data (
+                EXT_VIEWPORT, message,
+                &left, &top, &width, &height, &page_width, &page_height);
+            g_debug ("viewport changed %ld %ld %ld %ld %ld %ld",
+                     left, top, width, height, page_width, page_height);
+            break;
+        }
     default:
         {
             gchar *pmsg = g_variant_print (message, TRUE);


### PR DESCRIPTION
Because the dom event scroll has no concept of vertical scroll vs horizontal scroll the code simply issues both scroll events. We could track previous values and suppress redundant events but I'm not sure it would really bring any benefit.