### PR TITLE
Minor fix of `check_mkdir` macro

### DIFF
--- a/src/io.c
+++ b/src/io.c
@@ -606,6 +606,8 @@ create_dir (const gchar *dir)
     check_mkdir (work_path, 0700);
     g_free (work_path);
 
+#undef check_mkdir
+
     return EXIT_SUCCESS;
 }
 

--- a/src/io.c
+++ b/src/io.c
@@ -584,7 +584,7 @@ create_dir (const gchar *dir)
     }
 
 #define check_mkdir(dir, mode)                              \
-    if (mkdir (work_path, 0700)) {                          \
+    if (mkdir (dir, mode)) {                                \
         switch (errno) {                                    \
         case EEXIST:                                        \
             break;                                          \


### PR DESCRIPTION
The `check_mkdir` macro expects two arguments to be passed, but ignores them and instead uses hardcoded values.  That's currently not an issue as at both places where the macro is used, the arguments match the hardcoded values.  Might lead to some headaches as soon as this has to change, though.

Moreover, such a locally used macro should be undefined after the last place where it's used to avoid interference with later code.